### PR TITLE
Add pedquest landing page

### DIFF
--- a/assets/_design-system-overrides.scss
+++ b/assets/_design-system-overrides.scss
@@ -92,6 +92,13 @@
     a.link1 {
       color: #e76f50;
     }
+
+    .page-wrap {
+      @media (min-width: 48em) {
+        padding-bottom: 2em;
+        padding-top: 2em;
+      }
+    }
 }
 
 div.el-popper.is-customized {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -112,6 +112,8 @@ export default defineNuxtConfig({
       ctf_news_and_events_page_id: '27g94v7HnxrqsCKKA8Wf7o',
       ctf_tools_and_resources_page_id: '5gOQBmYpDBRPtJh7Yzj8SP',
       ctf_consortia_content_type_id: 'consortia',
+      ctf_pedquest_about_page_id: '2GgKi7i5bruGNdLTrIBV7t',
+      ctf_pedquest_collaborator_details: '1tbeLijAKo4toaZoyOLkTu',
       portal_api: process.env.PORTAL_API_HOST || 'https://sparc-api.herokuapp.com',
       DEPLOY_ENV: process.env.DEPLOY_ENV || 'development',
       ALGOLIA_API_KEY: process.env.ALGOLIA_API_KEY,

--- a/pages/about/collaborators/[collaboratorId].vue
+++ b/pages/about/collaborators/[collaboratorId].vue
@@ -14,9 +14,18 @@
       <div v-html="parseMarkdown(heroCopy)"></div>
     </page-hero>
     <div class="page-wrap container">
-      <h2>{{ collaboratorName }}</h2>
+      <h2>More Information</h2>
       <div v-html="parseMarkdown(aboutCollaborator)"></div>
-
+      <div class="contact-card-wrapper">
+          <el-card 
+          style="max-width: 480px">
+            <template #header>
+              <span>Contact Information</span>
+            </template>
+            <p>Wagenaar Lab</p>
+            <p><span>Email :</span><a :href="collaboratorEmail">{{ collaboratorEmail }}</a></p>
+          </el-card>
+      </div>
     </div>
   </div>
 </template>
@@ -33,13 +42,20 @@ export default {
       heroCopy: '',
       aboutCollaborator: '',
       collaboratorName: '',
+      collaboratorEmail: '',
       breadcrumb: [
         {
           to: {
             name: 'index'
           },
           label: 'Home'
-        }
+        },
+        {
+          to: {
+            name: 'about'
+          },
+          label: 'About Epilepsy.science'
+        },
       ],
     }
   },
@@ -60,7 +76,6 @@ export default {
         $contentfulClient
         .getEntry(config.public.ctf_pedquest_collaborator_details)
         .then(({fields}) => {
-          console.log('fields', fields)
           return {...fields}
         })
         .catch(err => console.error('Could not fetch page data from Contentful.', err)),
@@ -77,5 +92,12 @@ export default {
 @import 'sparc-design-system-components-2/src/assets/_variables.scss';
 .about-page {
   background-color: $background;
+}
+.contact-card-wrapper {
+  margin-top: 24px;
+  span {
+    font-weight: 600;
+    margin-right: 12px;
+  }
 }
 </style>

--- a/pages/about/collaborators/[collaboratorId].vue
+++ b/pages/about/collaborators/[collaboratorId].vue
@@ -1,0 +1,81 @@
+<template>
+  <Head>
+    <Title>{{ pageTitle }}</Title>
+    <Meta name="og:title" hid="og:title" :content="pageTitle" />
+    <Meta name="twitter:title" :content="pageTitle" />
+    <Meta name="description" hid="description" :content="heroCopy" />
+    <Meta name="og:description" hid="og:description" :content="heroCopy" />
+    <Meta name="twitter:description" :content="heroCopy" />
+  </Head>
+  <div class="about-page pb-16">
+    <breadcrumb :breadcrumb="breadcrumb" title="PedQuEST" />
+    <page-hero class="py-24" v-if="heroCopy">
+      <h1>{{ pageTitle }}</h1>
+      <div v-html="parseMarkdown(heroCopy)"></div>
+    </page-hero>
+    <div class="page-wrap container">
+      <h2>{{ collaboratorName }}</h2>
+      <div v-html="parseMarkdown(aboutCollaborator)"></div>
+
+    </div>
+  </div>
+</template>
+<script>
+import marked from '@/mixins/marked';
+
+export default {
+  name: 'CollaboratorDetails',
+
+  mixins: [marked],
+
+  data: () => {
+    return {
+      heroCopy: '',
+      aboutCollaborator: '',
+      collaboratorName: '',
+      breadcrumb: [
+        {
+          to: {
+            name: 'index'
+          },
+          label: 'Home'
+        }
+      ],
+    }
+  },
+
+  setup() {
+    const config = useRuntimeConfig()
+    const { $contentfulClient } = useNuxtApp()
+    return Promise.all([
+      /**
+       * Page data
+       */
+      $contentfulClient
+        .getEntry(config.public.ctf_pedquest_about_page_id)
+        .then(({fields}) => {
+          return {...fields}
+        })
+        .catch(err => console.error('Could not fetch page data from Contentful.', err)),
+        $contentfulClient
+        .getEntry(config.public.ctf_pedquest_collaborator_details)
+        .then(({fields}) => {
+          console.log('fields', fields)
+          return {...fields}
+        })
+        .catch(err => console.error('Could not fetch page data from Contentful.', err)),
+    ]).then(([header, details]) => {
+      return ({
+      ...header, ...details
+    })
+    })
+  }
+}
+</script>
+
+<style scoped lang="scss">
+@import 'sparc-design-system-components-2/src/assets/_variables.scss';
+.about-page {
+  background-color: $background;
+}
+</style>

--- a/pages/about/collaborators/[collaboratorId].vue
+++ b/pages/about/collaborators/[collaboratorId].vue
@@ -56,6 +56,12 @@ export default {
           },
           label: 'About Epilepsy.science'
         },
+        {
+          to: {
+            name: 'about'
+          },
+          label: 'Collaborators'
+        },
       ],
     }
   },

--- a/pages/about/collaborators/[collaboratorId].vue
+++ b/pages/about/collaborators/[collaboratorId].vue
@@ -41,7 +41,6 @@ export default {
     return {
       heroCopy: '',
       aboutCollaborator: '',
-      collaboratorName: '',
       collaboratorEmail: '',
       breadcrumb: [
         {

--- a/pages/about/index.vue
+++ b/pages/about/index.vue
@@ -77,8 +77,8 @@
         </p>
       </div>
       <div class="collaborators">
-        <span>Collaborators:</span>
-        <NuxtLink :to="{ name: 'about-collaborators-collaboratorId', params: { collaboratorId: 'pedquest' }}">View PedQuEST page</NuxtLink>
+        <h3>Collaborators</h3>
+        <NuxtLink :to="{ name: 'about-collaborators-collaboratorId', params: { collaboratorId: 'pedquest' }}">Visit PedQuEST page</NuxtLink>
       </div>
     </div>
   </div>
@@ -130,11 +130,5 @@ export default {
 @import 'sparc-design-system-components-2/src/assets/_variables.scss';
 .about-page {
   background-color: $background;
-}
-.collaborators {
-  span {
-    font-weight: 600;
-    margin-right: 16px;
-  }
 }
 </style>

--- a/pages/about/index.vue
+++ b/pages/about/index.vue
@@ -11,69 +11,75 @@
     <breadcrumb :breadcrumb="breadcrumb" title="About" />
     <page-hero class="py-24" v-if="heroCopy">
       <h1>{{ pageTitle }}</h1>
-      <div v-html="parseMarkdown(heroCopy)" />
+      <div v-html="parseMarkdown(heroCopy)"></div>
     </page-hero>
     <div class="page-wrap container">
-      <h3>What are we doing here at Epilepsy.Science?</h3>
+      <div class="epilepsy-about">
+        <h3>What are we doing here at Epilepsy.Science?</h3>
 
-      <p>
-        Epilepsy.Science is a new cloud-based platform for managing, analyzing,
-        publishing, and sharing scientific datasets to accelerate epilepsy
-        research. Led by PennSieve and the Brain Data Science Platform (BDSP)
-        and with support from the AWS Open Data Sponsorship Program, we are
-        creating an unparalleled open data resource for the epilepsy community.
-      </p>
+        <p>
+          Epilepsy.Science is a new cloud-based platform for managing, analyzing,
+          publishing, and sharing scientific datasets to accelerate epilepsy
+          research. Led by PennSieve and the Brain Data Science Platform (BDSP)
+          and with support from the AWS Open Data Sponsorship Program, we are
+          creating an unparalleled open data resource for the epilepsy community.
+        </p>
 
-      <p>
-        The mission of Epilepsy.Science is to drive progress in understanding,
-        treating, and ultimately curing epilepsy through open access to
-        multidimensional epilepsy data at scale. The platform provides over
-        200,000 EEG recordings from diverse contexts including routine
-        outpatient EEGs, critically ill patients, and epilepsy monitoring unit
-        evaluations. As it grows, it will also include extensive accompanying
-        clinical data like medications, imaging, genetics, and more from
-        institutions worldwide.
-      </p>
+        <p>
+          The mission of Epilepsy.Science is to drive progress in understanding,
+          treating, and ultimately curing epilepsy through open access to
+          multidimensional epilepsy data at scale. The platform provides over
+          200,000 EEG recordings from diverse contexts including routine
+          outpatient EEGs, critically ill patients, and epilepsy monitoring unit
+          evaluations. As it grows, it will also include extensive accompanying
+          clinical data like medications, imaging, genetics, and more from
+          institutions worldwide.
+        </p>
 
-      <p>
-        Researchers can use Epilepsy.Science to easily build customized cohorts
-        by connecting data points across datasets. The platform enables
-        scientists to publish -- at no cost -- high quality datasets for
-        citation, reuse, and reproducible research. By promoting open science,
-        Epilepsy.Science aims to accelerate discoveries and improve patient
-        outcomes.
-      </p>
+        <p>
+          Researchers can use Epilepsy.Science to easily build customized cohorts
+          by connecting data points across datasets. The platform enables
+          scientists to publish -- at no cost -- high quality datasets for
+          citation, reuse, and reproducible research. By promoting open science,
+          Epilepsy.Science aims to accelerate discoveries and improve patient
+          outcomes.
+        </p>
 
-      <p>This collaboration brings together:</p>
+        <p>This collaboration brings together:</p>
 
-      <ul>
-        <li>
-          Pennsieve’s scalable data management and sharing capabilities and
-          graph-based data integration model.
-        </li>
+        <ul>
+          <li>
+            Pennsieve’s scalable data management and sharing capabilities and
+            graph-based data integration model.
+          </li>
 
-        <li>
-          BDSP’s extensive data resources including over 200,000 EEG recordings
-          and genetics, imaging, and clinical data. BDSP also contributes a
-          library of open-source analytics tools.
-        </li>
+          <li>
+            BDSP’s extensive data resources including over 200,000 EEG recordings
+            and genetics, imaging, and clinical data. BDSP also contributes a
+            library of open-source analytics tools.
+          </li>
 
-        <li>
-          The AWS Open Data Sponsorship Program covers the cost of storage for
-          publicly available high-value cloud-optimized datasets. We work with
-          data providers who seek to democratize access to data by making it
-          available for analysis on AWS, develop new cloud-native techniques,
-          formats, and tools that lower the cost of working with data, and
-          encourage the development of communities that benefit from access to
-          shared datasets.
-        </li>
-      </ul>
+          <li>
+            The AWS Open Data Sponsorship Program covers the cost of storage for
+            publicly available high-value cloud-optimized datasets. We work with
+            data providers who seek to democratize access to data by making it
+            available for analysis on AWS, develop new cloud-native techniques,
+            formats, and tools that lower the cost of working with data, and
+            encourage the development of communities that benefit from access to
+            shared datasets.
+          </li>
+        </ul>
 
-      <p>
-        Epilepsy.Science offers unprecedented opportunities for open,
-        collaborative epilepsy research through its powerful data resources,
-        analytics tools, and cloud-based platform.
-      </p>
+        <p>
+          Epilepsy.Science offers unprecedented opportunities for open,
+          collaborative epilepsy research through its powerful data resources,
+          analytics tools, and cloud-based platform.
+        </p>
+      </div>
+      <div class="collaborators">
+        <span>Collaborators:</span>
+        <NuxtLink :to="{ name: 'about-collaborators-collaboratorId', params: { collaboratorId: 'pedquest' }}">View PedQuEST page</NuxtLink>
+      </div>
     </div>
   </div>
 </template>
@@ -124,5 +130,11 @@ export default {
 @import 'sparc-design-system-components-2/src/assets/_variables.scss';
 .about-page {
   background-color: $background;
+}
+.collaborators {
+  span {
+    font-weight: 600;
+    margin-right: 16px;
+  }
 }
 </style>

--- a/pages/about/index.vue
+++ b/pages/about/index.vue
@@ -20,7 +20,7 @@
         <p>
           Epilepsy.Science is a new cloud-based platform for managing, analyzing,
           publishing, and sharing scientific datasets to accelerate epilepsy
-          research. Led by PennSieve and the Brain Data Science Platform (BDSP)
+          research. Led by Pennsieve and the Brain Data Science Platform (BDSP)
           and with support from the AWS Open Data Sponsorship Program, we are
           creating an unparalleled open data resource for the epilepsy community.
         </p>


### PR DESCRIPTION
- Add PedQuEST landing page
- Fix styling in epilepsy.science 'About' page

PedQuEST landing page
<img width="1920" alt="pedquest-landing-page" src="https://github.com/user-attachments/assets/cb584fb0-3f92-4a1e-8516-de79f1a44804">

