### PR TITLE
Fix contentful api calls

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -11,91 +11,15 @@
 
 <script>
 import CookieNotice from '@/components/CookieNotice/CookieNotice.vue'
-import { propOr } from 'ramda'
-import DOMPurify from 'isomorphic-dompurify'
-import { useMainStore } from '../store/index.js'
-import { mapState } from 'pinia'
-
 export default {
   components: {
     CookieNotice,
   },
-  data() {
-    return {
-      store: useMainStore()
-    }
-  },
   computed: {
-    ...mapState(useMainStore, ['portalNotification']),
     hasAcceptedGDPR() {
       return useCookie('GDPR:accepted').value
     }
   },
-  mounted() {
-    this.showPortalNotification()
-  },
-  methods: {
-    showPortalNotification() {
-      const displayOnHomePageOnly = propOr("", 'displayOn', this.portalNotification) === 'Homepage Only'
-      const currentlyOnHomePage = this.$route.fullPath === "/"
-      const message = DOMPurify.sanitize(propOr("", 'message', this.portalNotification).trim(), {
-        ALLOWED_TAGS: ['a', 'br', 'sup'], // We allow links, line breaks, and sup tags
-        ALLOWED_ATTR: ['href'], // We allow the href attribute for links
-      })
-      const messageType = propOr("", 'messageType', this.portalNotification)
-      const onlyShowOnce = propOr(true, 'showOnce', this.portalNotification)
-      const stopShowingDate = propOr(undefined, 'stopShowingDate', this.portalNotification)
-      // If the stop showing time is not set then always display message, otherwise check if the date has passed
-      const stopShowing = stopShowingDate === undefined ? false : new Date(stopShowingDate).getTime() < new Date().getTime()
-      if (message != "" && !stopShowing) {
-        if (!onlyShowOnce || !useCookie('PortalNotification:hasBeenSeen').value || (useCookie('PortalNotification:message').value != this.portalNotification.message)) {
-          if (!displayOnHomePageOnly || (displayOnHomePageOnly && currentlyOnHomePage)) {
-            switch (messageType) {
-              case 'Error': {
-                this.$message({
-                  message: message,
-                  showClose: true,
-                  iconClass: 'el-icon-circle-close',
-                  customClass: 'el-message--error',
-                  dangerouslyUseHTMLString: true,
-                  duration: 0
-                })
-                break
-              }
-              case 'Success': {
-                this.$message({
-                  message: message,
-                  showClose: true,
-                  iconClass: 'el-icon-circle-check',
-                  customClass: 'el-message--success',
-                  dangerouslyUseHTMLString: true,
-                  duration: 0
-                })
-                break
-              }
-              case 'Information': {
-                this.$message({
-                  message: message,
-                  showClose: true,
-                  iconClass: 'about-icon',
-                  customClass: 'el-message--info',
-                  dangerouslyUseHTMLString: true,
-                  duration: 0
-                })
-                break
-              }
-            }
-            const today = new Date()
-            const expirationDate = new Date(today.setDate(today.getDate() + 30))
-            const hasBeenSeenCookie = useCookie('PortalNotification:hasBeenSeen', { expires: expirationDate })
-            hasBeenSeenCookie.value = true
-            const portalNotificationMessageCookie = useCookie('PortalNotification:message')
-            portalNotificationMessageCookie.value = this.portalNotification.message
-          }
-        }
-      }
-    }
-  }
 }
 </script>
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -146,7 +146,8 @@ export default defineNuxtConfig({
         "https://api.pennsieve.io/discover",
       CTF_SPACE_ID: process.env.CTF_SPACE_ID,
       CTF_CDA_ACCESS_TOKEN: process.env.CTF_CDA_ACCESS_TOKEN,
-      CTF_API_HOST: process.env.CTF_API_HOST || "preview.contentful.com",
+      CTF_CPA_ACCESS_TOKEN: process.env.CTF_CPA_ACCESS_TOKEN,
+      CTF_API_HOST: process.env.CTF_API_HOST || "cdn.contentful.com",
       ctf_pedquest_about_page_id: "2GgKi7i5bruGNdLTrIBV7t",
       ctf_pedquest_collaborator_details: "1tbeLijAKo4toaZoyOLkTu",
       portal_api:

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -147,8 +147,6 @@ export default defineNuxtConfig({
       CTF_SPACE_ID: process.env.CTF_SPACE_ID,
       CTF_CDA_ACCESS_TOKEN: process.env.CTF_CDA_ACCESS_TOKEN,
       CTF_API_HOST: process.env.CTF_API_HOST || "preview.contentful.com",
-      ctf_home_page_id: "4KuOw0SnxWqN7SZ6W68oey",
-      ctf_portal_notification_entry_id: "1kGepfPts4FM3tDfOGVPnQ",
       ctf_pedquest_about_page_id: "2GgKi7i5bruGNdLTrIBV7t",
       ctf_pedquest_collaborator_details: "1tbeLijAKo4toaZoyOLkTu",
       portal_api:

--- a/plugins/contentful.js
+++ b/plugins/contentful.js
@@ -27,9 +27,14 @@ function wrapClientWithFallback(client) {
 export default defineNuxtPlugin(() => {
   const config = useRuntimeConfig();
 
+  const isPreview = config.public.CTF_API_HOST === "preview.contentful.com";
+  const accessToken = isPreview
+    ? config.public.CTF_CPA_ACCESS_TOKEN
+    : config.public.CTF_CDA_ACCESS_TOKEN;
+
   const client = createClient({
     space: config.public.CTF_SPACE_ID,
-    accessToken: config.public.CTF_CDA_ACCESS_TOKEN,
+    accessToken,
     host: config.public.CTF_API_HOST,
     retryOnError: false,
   });

--- a/plugins/pinia.js
+++ b/plugins/pinia.js
@@ -3,7 +3,6 @@ import { useMainStore } from '~/store/index'
 
 export default defineNuxtPlugin(async (nuxtApp) => {
   const store = useMainStore(nuxtApp.$pinia)
-  await store.init()
   return {
     provide: {
       store: store

--- a/store/index.js
+++ b/store/index.js
@@ -3,8 +3,6 @@ import { mockPageStats } from '~/data/mockData';
 
 export const useMainStore = defineStore('main', {
   state: () => ({
-    footerData: {},
-    portalNotification: {},
     datasetInfo: {},
     datasetTypeName: "",
     datasetFacetsData: [],
@@ -19,15 +17,6 @@ export const useMainStore = defineStore('main', {
     selectedPackage: {},
   }),
   actions: {
-    async init() {
-      await Promise.all([, this.fetchFooterData(), this.fetchPortalNotification()])
-    },
-    setFooterData(value) {
-      this.footerData = value
-    },
-    setPortalNotification(value) {
-      this.portalNotification = value
-    },
     setDatasetInfo(value) {
       this.datasetInfo = value
     },
@@ -36,23 +25,6 @@ export const useMainStore = defineStore('main', {
     },
     setDatasetFacetsData(value) {
       this.datasetFacetsData = value
-    },
-    async fetchPortalNotification() {
-      try {
-        const response = await useNuxtApp().$contentfulClient.getEntry(useRuntimeConfig().public.ctf_portal_notification_entry_id)
-        this.setPortalNotification(response.fields)
-      } catch (e) {
-        console.error(e)
-      }
-    },
-    async fetchFooterData() {
-      try {
-        const response = await useNuxtApp().$contentfulClient.getEntry(useRuntimeConfig().public.ctf_home_page_id)
-        const { footerDescription, learnMoreLinks, policiesLinks, helpUsImproveLinks, stayUpdatedLinks } = response.fields
-        this.setFooterData({ footerDescription, learnMoreLinks, policiesLinks, helpUsImproveLinks, stayUpdatedLinks })
-      } catch (e) {
-        console.error(e)
-      }
     },
     setPageStats(value) {
       this.pageStats = {


### PR DESCRIPTION
- removed unused notification API call (would add this manually, if needed)
- removed unused footer API call
- updated dev env to use Contentful's Preview API instead of the Delivery API to save the Delivery API limit.
- Reduced 2 excess API calls for every reload, and API calls used while in Dev environment/app development.