### PR TITLE
Fix file viewer

### DIFF
--- a/components/Dataset/PackageDetails/PackageDetails.vue
+++ b/components/Dataset/PackageDetails/PackageDetails.vue
@@ -67,23 +67,19 @@ function downloadFile(event) {
 
 <template>
   <div class="dataset-details">
-    <div class="row between-mb action-row">
-        <div class="col-xs-8 back-link-col">
-          <nuxt-link :to="backToFilesRoute" class="back-link">
-            <IconArrowLeft class="back-link-icon" />
-            <span>{{ backLinkLabel }}</span>
-          </nuxt-link>
-        </div>
-        <div class="col-xs row end-xs">
-          <bf-button
-            key="btn-get-dataset"
-            class="get-dataset-button"
-            @click="downloadFile"
-          >
-            {{downloadContent}}
-          </bf-button>
-        </div>
-      </div>
+    <div class="action-row">
+      <nuxt-link :to="backToFilesRoute" class="back-link">
+        <IconArrowLeft class="back-link-icon" />
+        <span>{{ backLinkLabel }}</span>
+      </nuxt-link>
+      <bf-button
+        key="btn-get-dataset"
+        class="get-dataset-button"
+        @click="downloadFile"
+      >
+        {{ downloadContent }}
+      </bf-button>
+    </div>
       <div class="package-content">
         <el-table
           class="table"
@@ -119,7 +115,7 @@ function downloadFile(event) {
 }
 
 .table {
-  margin-top: 24px;
+  margin-top: 12px;
 
   .file-name-container {
     display: flex;
@@ -183,12 +179,9 @@ function downloadFile(event) {
 }
 
 .action-row {
-  align-items: center;
-}
-
-.back-link-col {
   display: flex;
   align-items: center;
+  justify-content: space-between;
 }
 
 .back-link {

--- a/components/Dataset/PackageDetails/PackageDetails.vue
+++ b/components/Dataset/PackageDetails/PackageDetails.vue
@@ -167,11 +167,6 @@ function downloadFile(event) {
 
           </el-table>
         </div>
-
-        <h3 class="package-content-title">
-          Viewer
-        </h3>
-
       </div>
     </div>
 

--- a/components/Dataset/PackageDetails/PackageDetails.vue
+++ b/components/Dataset/PackageDetails/PackageDetails.vue
@@ -1,13 +1,9 @@
 <script setup>
+import { pathOr } from 'ramda'
+import { useMainStore } from '~/store/index.js'
+import BfButton from '~/components/Shared/BfButton/BfButton.vue'
 
-import {ref} from 'vue'
-import {pathOr, propOr} from "ramda";
 const runtimeConfig = useRuntimeConfig()
-
-
-import {useMainStore} from '~/store/index.js'
-import BfButton from "~/components/Shared/BfButton/BfButton.vue";
-
 const store = useMainStore()
 
 const parentFolderPath = computed(() => {
@@ -33,99 +29,40 @@ const backToFilesRoute = computed(() => {
 
 const backLinkLabel = 'Back to files'
 
-const headerContent = computed(() => {
-  const files = propOr(store.selectedPackage,'files',[])
-  return files.length > 1 ? "Package Files": "File Details"
-})
-
 const downloadContent = computed(() => {
-  const files = propOr(store.selectedPackage,'files',[])
-  return files.length > 1 ? "Download Package": "Download File"
+  const files = store.selectedPackage?.files || []
+  return files.length > 1 ? 'Download Package' : 'Download File'
 })
-
-const zipitUrl = computed(() => {
-  return `${runtimeConfig.public.zipit_api_host}`
-})
-
-const zipData = ref({})
 
 function formatStorage(row, column, cellValue) {
   return useFormatMetric(cellValue)
 }
 
-function sizeString(sizeInBytes) {
-  return useFormatMetric(sizeInBytes)
-}
-
-function onDownloadClick() {
-  executeDownload()
-}
-
-const archiveName = ref('')
-const selected = ref([])
-const zipFormRef = ref(null)
-
-
-async function executeDownload() {
-
-
-  const mainPayload = {
-    paths: store.selectedPackage.files.map((f) => {
-      return f.path
-    }),
-    datasetId: store.selectedPackage.datasetId,
-    version: store.selectedPackage.version,
-  }
-
-  const rootPathPayload = {} // path ? { rootPath: path.join('/') } : {}
-  const archiveNamePayload =
-    archiveName && selected.length > 1
-      ? { archiveName: archiveName.value }
-      : {}
-
-  const payload = {
-    ...mainPayload,
-    ...rootPathPayload,
-    ...archiveNamePayload
-  }
-  zipData.value = JSON.stringify(payload, undefined)
-
-  zipFormRef.value.submit() // eslint-disable-line no-undef
-}
-
 function downloadFile(event) {
-  event.preventDefault();
+  event.preventDefault()
 
   const datasetId = store.selectedPackage.datasetId
   const version = store.selectedPackage.version
-  const filePath = store.selectedPackage.files.map((f) => {
-    return f.path
-  })
+  const filePaths = store.selectedPackage.files.map((f) => f.path)
 
-  // Get PresignedUrl
   const manifestUrl = `${runtimeConfig.public.discover_api_host}/datasets/${datasetId}/versions/${version}/files/download-manifest`
-  useSendXhr(manifestUrl,{
-    method:"POST",
-    body:{
-      paths: filePath
-    }
+  useSendXhr(manifestUrl, {
+    method: 'POST',
+    body: { paths: filePaths }
   })
     .then(response => {
-      const presignedUrl = pathOr('',['data',[0],'url'], response)
+      const presignedUrl = pathOr('', ['data', [0], 'url'], response)
       if (presignedUrl) {
-        const link = document.createElement('a');
-        link.href = presignedUrl;
-        link.setAttribute('download',true);
-        link.setAttribute('target','_blank')
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
+        const link = document.createElement('a')
+        link.href = presignedUrl
+        link.setAttribute('download', true)
+        link.setAttribute('target', '_blank')
+        document.body.appendChild(link)
+        link.click()
+        document.body.removeChild(link)
       }
     })
 }
-
-
-
 </script>
 
 <template>

--- a/components/Dataset/PackageDetails/PackageDetails.vue
+++ b/components/Dataset/PackageDetails/PackageDetails.vue
@@ -49,14 +49,6 @@ const zipitUrl = computed(() => {
 
 const zipData = ref({})
 
-function formatType(row) {
-  return row.fileType
-}
-
-function formatHeader(row, index) {
-  return "background-color: red;"
-}
-
 function formatStorage(row, column, cellValue) {
   return useFormatMetric(cellValue)
 }
@@ -138,8 +130,7 @@ function downloadFile(event) {
 
 <template>
   <div class="dataset-details">
-    <div class="container-fluid">
-      <div class="row between-mb action-row">
+    <div class="row between-mb action-row">
         <div class="col-xs-8 back-link-col">
           <nuxt-link :to="backToFilesRoute" class="back-link">
             <IconArrowLeft class="back-link-icon" />
@@ -157,81 +148,101 @@ function downloadFile(event) {
         </div>
       </div>
       <div class="package-content">
-<!--        <div class="button-row">-->
-<!--          <h3 class="package-content-title">-->
-<!--            {{headerContent}}-->
-<!--          </h3>-->
-
-
-
-        <div class="file-info">
-          <el-table
-            ref="table"
-            class="table"
-            :data="store.selectedPackage.files"
-            :highlight-current-row="false"
-            border
-            header-row-class-name="header-class"
-          >
-            <el-table-column label="File Name">
-              <template #default="scope">
-                <div class="file-name-container">
-                  <img :src="useFileIcon(scope.row.icon, scope.row.type)" alt="Icon" />
-                  <div class="name">
-                      {{ scope.row.name }}
-                  </div>
-                </div>
-              </template>
-            </el-table-column>
-            <el-table-column :formatter="formatType" label="Type" />
-            <el-table-column prop="size" label="Size" :formatter="formatStorage" />
-            <el-table-column prop="uri" label="URI" min-width="200px" align="right"/>
-
-          </el-table>
-        </div>
+        <el-table
+          class="table"
+          :data="store.selectedPackage.files"
+          :highlight-current-row="false"
+        >
+          <el-table-column label="File Name">
+            <template #default="scope">
+              <div class="file-name-container">
+                <img :src="useFileIcon(scope.row.icon, scope.row.type)" alt="" />
+                <span class="name">{{ scope.row.name }}</span>
+              </div>
+            </template>
+          </el-table-column>
+          <el-table-column prop="fileType" label="Type" width="120" />
+          <el-table-column prop="size" label="Size" :formatter="formatStorage" width="120" />
+          <el-table-column prop="uri" label="URI" min-width="240" />
+        </el-table>
       </div>
-    </div>
-
-
-<!--    <form ref="zipFormRef" id="zipForm" method="POST" :action="downloadFile">-->
-<!--      <input v-model="zipData" type="hidden" name="data" />-->
-<!--    </form>-->
   </div>
 </template>
 
 <style lang="scss" scoped>
+.get-dataset-button {
+  font-weight: 600;
+  line-height: 16px;
+  font-size: 14px;
+  background-color: $purple_3;
 
-.file-info {
-  margin-top: 24px;
+  &:focus {
+    background-color: $purple_3;
+  }
 }
 
 .table {
+  margin-top: 24px;
+
   .file-name-container {
     display: flex;
+    align-items: center;
+    gap: 8px;
 
     img {
-      height: 20px;
-      width: 20px;
-      margin: 2px 5px 0px 0px;
+      height: 18px;
+      width: 18px;
+      flex-shrink: 0;
     }
 
     .name {
-      margin-top: 0px;
+      color: $text-color;
+      word-break: break-word;
     }
   }
 }
 
 :deep(.el-table) {
-  .el-table--border {
-    border: none;
+  width: 100%;
+  table-layout: fixed;
+
+  .el-table__body-wrapper {
+    border: solid 1px $cortex;
+    border-top: none;
   }
+
+  &::before {
+    display: none;
+  }
+
+  th.is-leaf {
+    background-color: $axon;
+    color: #000;
+    font-size: 14px;
+    font-weight: 500;
+    border-top: solid 1px $cortex;
+    border-left: solid 1px $cortex;
+
+    &:last-child {
+      border-right: solid 1px $cortex;
+    }
+  }
+
   .el-table__header-wrapper {
     height: 40px;
   }
-}
 
-.dataset-details {
-  margin-top: 24px;
+  td.el-table__cell {
+    border-color: $cortex;
+    border-right: none;
+    font-size: 14px;
+    color: $text-color;
+
+    .cell {
+      word-break: break-all;
+      white-space: normal;
+    }
+  }
 }
 
 .action-row {
@@ -246,32 +257,23 @@ function downloadFile(event) {
 .back-link {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  color: #297fca;
+  color: $purple_2;
   font-size: 14px;
   font-weight: 600;
-  line-height: 1;
+  line-height: 16px;
   text-decoration: none;
-  transition: color 0.15s ease;
 
-  &:hover,
-  &:focus-visible {
-    color: #1c5f9b;
-    text-decoration: none;
-
-    .back-link-icon {
-      transform: translateX(-2px);
-    }
+  &:focus {
+    color: $purple_2;
   }
 
   .back-link-icon {
-    height: 14px;
-    width: 14px;
-    color: currentColor;
-    transition: transform 0.15s ease;
+    color: $purple_2;
+    height: 10px;
+    width: 10px;
+    margin-right: 4px;
   }
 }
-
 
 .package-content {
   display: flex;

--- a/components/Dataset/PackageDetails/PackageDetails.vue
+++ b/components/Dataset/PackageDetails/PackageDetails.vue
@@ -139,11 +139,11 @@ function downloadFile(event) {
 <template>
   <div class="dataset-details">
     <div class="container-fluid">
-      <div class="row between-mb">
-        <div class="col-xs-8 header-link">
-          <nuxt-link :to="backToFilesRoute">
-            <IconArrowLeft class="header-link-icon" />
-            {{ backLinkLabel }}
+      <div class="row between-mb action-row">
+        <div class="col-xs-8 back-link-col">
+          <nuxt-link :to="backToFilesRoute" class="back-link">
+            <IconArrowLeft class="back-link-icon" />
+            <span>{{ backLinkLabel }}</span>
           </nuxt-link>
         </div>
         <div class="col-xs row end-xs">
@@ -155,7 +155,6 @@ function downloadFile(event) {
             {{downloadContent}}
           </bf-button>
         </div>
-
       </div>
       <div class="package-content">
 <!--        <div class="button-row">-->
@@ -205,11 +204,6 @@ function downloadFile(event) {
 .file-info {
   margin-top: 24px;
 }
-.el-table--border {
-  border: 1px solid $gray_2;
-}
-
-
 
 .table {
   .file-name-container {
@@ -229,64 +223,59 @@ function downloadFile(event) {
 
 :deep(.el-table) {
   .el-table--border {
-    border:none
+    border: none;
   }
   .el-table__header-wrapper {
     height: 40px;
-
-    .el-table__header {
-    }
   }
-
 }
 
 .dataset-details {
   margin-top: 24px;
 }
 
-.header-link {
-  color: $purple_1;
+.action-row {
+  align-items: center;
+}
+
+.back-link-col {
+  display: flex;
+  align-items: center;
+}
+
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: #297fca;
   font-size: 14px;
   font-weight: 600;
-  line-height: 16px;
+  line-height: 1;
+  text-decoration: none;
+  transition: color 0.15s ease;
 
-  &:focus {
-    color: $purple_2;
+  &:hover,
+  &:focus-visible {
+    color: #1c5f9b;
+    text-decoration: none;
 
+    .back-link-icon {
+      transform: translateX(-2px);
+    }
   }
-  &:hover {
-    text-decoration: underline;
-  }
 
-  .header-link-icon {
-    color: $purple_1;
-    height: 10px;
-    width: 10px;
-    margin-bottom: 3px;
-    margin-right: 8px;
+  .back-link-icon {
+    height: 14px;
+    width: 14px;
+    color: currentColor;
+    transition: transform 0.15s ease;
   }
 }
+
 
 .package-content {
-  display:flex;
-  flex-direction: column ;
+  display: flex;
+  flex-direction: column;
   justify-content: space-between;
-
-  .button-row {
-    display:flex;
-    flex-direction: row;
-    justify-content: space-between;
-  }
 }
-
-.package-content-title {
-  color: $gray_4;
-  font-size: 16px;
-  font-weight: 500;
-  line-height: 40px;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-}
-
-
 </style>

--- a/components/Dataset/PackageDetails/PackageDetails.vue
+++ b/components/Dataset/PackageDetails/PackageDetails.vue
@@ -10,6 +10,29 @@ import BfButton from "~/components/Shared/BfButton/BfButton.vue";
 
 const store = useMainStore()
 
+const parentFolderPath = computed(() => {
+  const files = store.selectedPackage?.files || []
+  if (files.length === 0) return ''
+  const filePath = files[0].path || ''
+  const lastSlash = filePath.lastIndexOf('/')
+  return lastSlash > 0 ? filePath.substring(0, lastSlash) : ''
+})
+
+const backToFilesRoute = computed(() => {
+  const datasetId = store.selectedPackage?.datasetId
+  const route = {
+    name: 'datasets-datasetId',
+    params: { datasetId },
+    hash: '#files'
+  }
+  if (parentFolderPath.value) {
+    route.query = { path: parentFolderPath.value }
+  }
+  return route
+})
+
+const backLinkLabel = 'Back to files'
+
 const headerContent = computed(() => {
   const files = propOr(store.selectedPackage,'files',[])
   return files.length > 1 ? "Package Files": "File Details"
@@ -118,9 +141,9 @@ function downloadFile(event) {
     <div class="container-fluid">
       <div class="row between-mb">
         <div class="col-xs-8 header-link">
-          <nuxt-link :to="{ name: 'datasets-datasetId', params: { datasetId: store.selectedPackage.datasetId } }">
+          <nuxt-link :to="backToFilesRoute">
             <IconArrowLeft class="header-link-icon" />
-            Back to dataset
+            {{ backLinkLabel }}
           </nuxt-link>
         </div>
         <div class="col-xs row end-xs">

--- a/components/Datasets/DatasetFiles/DatasetFiles.vue
+++ b/components/Datasets/DatasetFiles/DatasetFiles.vue
@@ -327,7 +327,7 @@ function getRouteParams(data) {
               <ClientOnly>
                 <a
                   href="#"
-                  @click.prevent="getDatasetFiles(scope.row.path, scope.row.name)"
+                  @click.prevent="getDatasetFiles(scope.row.path)"
                 >
                   {{ scope.row.name }}
                 </a>

--- a/components/Datasets/DatasetFiles/DatasetFiles.vue
+++ b/components/Datasets/DatasetFiles/DatasetFiles.vue
@@ -9,6 +9,7 @@ import DatasetFilesFooter from "~/components/Datasets/DatasetFilesFooter/Dataset
 import DatasetFilesHeader from "~/components/Datasets/DatasetFilesHeader/DatasetFilesHeader.vue";
 
 const store = useMainStore()
+const route = useRoute()
 const DEFAULT_ARCHIVE_NAME = 'pennsieve-discover-data'
 const runtimeConfig = useRuntimeConfig()
 
@@ -37,7 +38,8 @@ watch(getFilesUrl, () => {
 })
 
 onMounted(() => {
-  getDatasetFiles()
+  const initialPath = route.query.path || ''
+  getDatasetFiles(initialPath)
 })
 
 const isLoggedin = ref(false)

--- a/components/Datasets/DatasetFiles/DatasetFiles.vue
+++ b/components/Datasets/DatasetFiles/DatasetFiles.vue
@@ -256,9 +256,9 @@ function closeConfirmDownload() {
 
 // ---- ROUTING ----
 function getRouteParams(data) {
-  const  sourcePackageId  = data.sourcePackageId ? data.sourcePackageId : "details"
+  const fileId = data.sourcePackageId || data.name
   return { name: 'package-id',
-    params: { id: sourcePackageId } }
+    params: { id: fileId } }
 }
 
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@element-plus/icons-vue": "^2.3.1",
     "@element-plus/nuxt": "^1.0.6",
     "@nuxtjs/sitemap": "^5.1.4",
-    "@pennsieve-viz/core": "^0.3.0",
+    "@pennsieve-viz/core": "^0.3.1",
     "@pinia-plugin-persistedstate/nuxt": "^1.2.0",
     "@pinia/nuxt": "^0.5.1",
     "algoliasearch": "^4.19.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@element-plus/icons-vue": "^2.3.1",
     "@element-plus/nuxt": "^1.0.6",
     "@nuxtjs/sitemap": "^5.1.4",
+    "@pennsieve-viz/core": "^0.3.0",
     "@pinia-plugin-persistedstate/nuxt": "^1.2.0",
     "@pinia/nuxt": "^0.5.1",
     "algoliasearch": "^4.19.1",

--- a/pages/package/[id].vue
+++ b/pages/package/[id].vue
@@ -194,22 +194,20 @@ onMounted(() => {
   margin-bottom: 2rem;
 }
 
-.pennsieve-viewer {
-  display: flex;
-}
-
 .package-viewer {
   padding-inline: 2rem;
   padding-bottom: 4rem;
+  margin-top: 2rem;
 }
 
 .viewer-title {
   color: $gray_4;
-  font-size: 16px;
-  font-weight: 500;
-  line-height: 40px;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.4;
   text-transform: uppercase;
-  letter-spacing: 0.5px;
+  letter-spacing: 0.6px;
+  margin: 0 0 12px;
 }
 
 .viewer-wrapper {
@@ -228,30 +226,13 @@ onMounted(() => {
   }
 }
 
-.csv-viewer-container {
-  width: 100%;
-  margin-top: 1rem;
-  margin-bottom: 2rem;
-}
-
-.markdown-viewer-container {
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  margin-top: 1rem;
-  margin-bottom: 2rem;
-}
-
+.csv-viewer-container,
+.markdown-viewer-container,
 .text-viewer-container {
   width: 100%;
-  display: flex;
-  justify-content: center;
-  margin-top: 1rem;
-  margin-bottom: 2rem;
 }
 
 .text-viewer-id {
   width: 100%;
-  max-width: 1200px;
 }
 </style>

--- a/pages/package/[id].vue
+++ b/pages/package/[id].vue
@@ -194,7 +194,7 @@ onMounted(() => {
 }
 
 .package-details-content {
-  margin-bottom: 28px;
+  margin-bottom: 48px;
 }
 
 .package-viewer {

--- a/pages/package/[id].vue
+++ b/pages/package/[id].vue
@@ -1,7 +1,8 @@
 <script setup>
 import { useMainStore } from "~/store/index.js";
 import { ref, onMounted, computed, shallowRef } from "vue";
-import { Markdown, TextViewer } from "pennsieve-visualization";
+import { Markdown, TextViewer, CSVViewer } from "@pennsieve-viz/core";
+import "@pennsieve-viz/core/style.css";
 
 // Dynamic imports for browser-only tsviewer
 const TSViewer = shallowRef(null);
@@ -18,6 +19,8 @@ if (import.meta.client) {
 const runtimeConfig = useRuntimeConfig();
 const store = useMainStore();
 const fileType = ref("");
+const fileUri = ref("");
+const presignedUrl = ref("");
 const isLoading = ref(true);
 const fileContent = ref("");
 const isLoadingContent = ref(false);
@@ -25,7 +28,8 @@ const contentError = ref("");
 const { fetchFileContent } = useFileContent();
 
 const timeseriesFileTypes = ["MEF", "EDF", "BDF", "NWB"]
-const textFileTypes = ["TXT", "CSV", "JSON", "XML", "LOG", "YAML", "YML"]
+const csvFileTypes = ["CSV", "TSV"]
+const textFileTypes = ["TXT", "JSON", "XML", "LOG", "YAML", "YML"]
 const markdownFileTypes = ["MD", "MARKDOWN"]
 
 const isReady = computed(() => !isLoading.value && !!fileType.value)
@@ -34,10 +38,24 @@ const viewerType = computed(() => {
   if (!isReady.value) return null
   const type = fileType.value.toUpperCase()
   if (timeseriesFileTypes.includes(type)) return "timeseries"
+  if (csvFileTypes.includes(type)) return "csv"
   if (markdownFileTypes.includes(type)) return "markdown"
   if (textFileTypes.includes(type)) return "text"
   return "unsupported"
 })
+
+async function fetchPresignedUrl(filePath, datasetId, version) {
+  const manifestUrl = `${runtimeConfig.public.discover_api_host}/datasets/${datasetId}/versions/${version}/files/download-manifest`;
+  try {
+    const response = await useSendXhr(manifestUrl, {
+      method: "POST",
+      body: { paths: [filePath] },
+    });
+    presignedUrl.value = response?.data?.[0]?.url || "";
+  } catch {
+    // presignedUrl stays empty; CSVViewer won't render
+  }
+}
 
 async function loadFileContent(file, datasetId, version) {
   isLoadingContent.value = true;
@@ -67,6 +85,7 @@ function fetchFileDetails() {
   useSendXhr(fileDetailUrl, { method: "GET" })
     .then((response) => {
       fileType.value = response.fileType || "";
+      fileUri.value = response.uri || "";
       store.setSelectedPackage({
         datasetId,
         version,
@@ -76,12 +95,19 @@ function fetchFileDetails() {
       if ([...textFileTypes, ...markdownFileTypes].includes(type)) {
         loadFileContent(response, datasetId, version);
       }
+      if (csvFileTypes.includes(type)) {
+        fetchPresignedUrl(response.path, datasetId, version);
+      }
     })
     .catch(() => {
       fileType.value = fileData.fileType || "";
+      fileUri.value = fileData.uri || "";
       const type = (fileData.fileType || "").toUpperCase();
       if ([...textFileTypes, ...markdownFileTypes].includes(type)) {
         loadFileContent(fileData, datasetId, version);
+      }
+      if (csvFileTypes.includes(type)) {
+        fetchPresignedUrl(fileData.path, datasetId, version);
       }
     })
     .finally(() => {
@@ -111,6 +137,16 @@ onMounted(() => {
           <component :is="TSViewer" v-if="TSViewer" />
           <div v-else class="viewer-message">Loading viewer...</div>
         </client-only>
+
+        <!-- CSV/TSV Viewer -->
+        <div v-else-if="viewerType === 'csv'" class="csv-viewer-container">
+          <CSVViewer
+            v-if="presignedUrl"
+            :src-url="presignedUrl"
+            :file-type="fileType"
+            :rows-per-page="25"
+          />
+        </div>
 
         <!-- Markdown Viewer -->
         <div
@@ -185,6 +221,12 @@ onMounted(() => {
     background-color: #ffebe9;
     border-radius: 6px;
   }
+}
+
+.csv-viewer-container {
+  width: 100%;
+  margin-top: 1rem;
+  margin-bottom: 2rem;
 }
 
 .markdown-viewer-container {

--- a/pages/package/[id].vue
+++ b/pages/package/[id].vue
@@ -138,9 +138,54 @@ function getFileType(uri) {
   return "text";
 }
 
-onMounted((to, from) => {
+function fetchFileDetails() {
+  const selectedPackage = store.selectedPackage;
+  if (!selectedPackage || !selectedPackage.files || selectedPackage.files.length === 0) {
+    isLoading.value = false;
+    return;
+  }
+
+  const fileData = selectedPackage.files[0];
+  const { datasetId, version } = selectedPackage;
+  const filePath = fileData.path;
+
+  const fileDetailUrl = `${runtimeConfig.public.discover_api_host}/datasets/${datasetId}/versions/${version}/files?path=${encodeURIComponent(filePath)}`;
+
+  useSendXhr(fileDetailUrl, { method: "GET" })
+    .then((response) => {
+      fileUri.value = response.uri || "";
+
+      if (isMarkdownFile(response.uri)) {
+        packageType.value = "Markdown";
+      } else {
+        packageType.value = response.packageType || "";
+      }
+
+      store.setSelectedPackage({
+        datasetId,
+        version,
+        files: [response],
+      });
+    })
+    .catch(() => {
+      // Fall back to store data if the endpoint fails
+      fileUri.value = fileData.uri || "";
+      if (isMarkdownFile(fileData.uri)) {
+        packageType.value = "Markdown";
+      } else {
+        packageType.value = fileData.packageType || "";
+      }
+    })
+    .finally(() => {
+      isLoading.value = false;
+    });
+}
+
+onMounted(() => {
   if (route.params.id !== "details") {
     getPackageFiles(PackageFilesUrl);
+  } else {
+    fetchFileDetails();
   }
 });
 </script>

--- a/pages/package/[id].vue
+++ b/pages/package/[id].vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useMainStore } from "~/store/index.js";
-import { ref, onMounted, computed, watch, shallowRef } from "vue";
+import { ref, onMounted, computed, shallowRef } from "vue";
 import { Markdown, TextViewer } from "pennsieve-visualization";
 
 // Dynamic imports for browser-only tsviewer
@@ -17,80 +17,38 @@ if (import.meta.client) {
 
 const runtimeConfig = useRuntimeConfig();
 const store = useMainStore();
-const packageType = ref("");
-const fileUri = ref("");
+const fileType = ref("");
 const isLoading = ref(true);
-const viewerState = computed(() => {
-  if (!packageType.value) {
-    return { type: "processing", message: "Processing package information..." };
+const fileContent = ref("");
+const isLoadingContent = ref(false);
+const contentError = ref("");
+const { fetchFileContent } = useFileContent();
+
+const timeseriesFileTypes = ["MEF", "EDF", "BDF", "NWB"]
+const textFileTypes = ["TXT", "CSV", "JSON", "XML", "LOG", "YAML", "YML"]
+const markdownFileTypes = ["MD", "MARKDOWN"]
+
+const isReady = computed(() => !isLoading.value && !!fileType.value)
+
+const viewerType = computed(() => {
+  if (!isReady.value) return null
+  const type = fileType.value.toUpperCase()
+  if (timeseriesFileTypes.includes(type)) return "timeseries"
+  if (markdownFileTypes.includes(type)) return "markdown"
+  if (textFileTypes.includes(type)) return "text"
+  return "unsupported"
+})
+
+async function loadFileContent(file, datasetId, version) {
+  isLoadingContent.value = true;
+  contentError.value = "";
+  try {
+    fileContent.value = await fetchFileContent(file, datasetId, version);
+  } catch (error) {
+    contentError.value = error.message || "Failed to load file content";
+  } finally {
+    isLoadingContent.value = false;
   }
-
-  if (isLoading.value) {
-    return { type: "loading", message: "Loading viewer..." };
-  }
-
-  // Handle Markdown
-  if (packageType.value === "Markdown" || isMarkdownFile(fileUri.value)) {
-    return { type: "markdown", message: null };
-  }
-
-  // Handle Text-based files
-  if (isTextFile(fileUri.value)) {
-    return {
-      type: "text",
-      message: null,
-      fileType: getFileType(fileUri.value),
-    };
-  }
-
-  // Handle TimeSeries
-  if (packageType.value === "TimeSeries") {
-    if (!isReady.value) {
-      return {
-        type: "error",
-        message:
-          "File is not processed, please try processing the timeseries file.",
-      };
-    }
-    return { type: "timeseries", message: null };
-  }
-
-  return {
-    type: "unsupported",
-    message: "Viewer is not available for this file type.",
-  };
-});
-
-// FUNCTIONS HELPER
-function isMarkdownFile(uri) {
-  if (!uri) return false;
-  const lowerUri = uri.toLowerCase();
-  return lowerUri.endsWith(".md") || lowerUri.endsWith(".markdown");
-}
-
-function isTextFile(uri) {
-  if (!uri) return false;
-  const lowerUri = uri.toLowerCase();
-  const textExtensions = [
-    ".txt",
-    ".csv",
-    ".json",
-    ".xml",
-    ".log",
-    ".yaml",
-    ".yml",
-  ];
-  return textExtensions.some((ext) => lowerUri.endsWith(ext));
-}
-
-function getFileType(uri) {
-  if (!uri) return "text";
-  const lowerUri = uri.toLowerCase();
-  if (lowerUri.endsWith(".csv")) return "csv";
-  if (lowerUri.endsWith(".json")) return "json";
-  if (lowerUri.endsWith(".xml")) return "xml";
-  if (lowerUri.endsWith(".yaml") || lowerUri.endsWith(".yml")) return "yaml";
-  return "text";
 }
 
 function fetchFileDetails() {
@@ -108,27 +66,22 @@ function fetchFileDetails() {
 
   useSendXhr(fileDetailUrl, { method: "GET" })
     .then((response) => {
-      fileUri.value = response.uri || "";
-
-      if (isMarkdownFile(response.uri)) {
-        packageType.value = "Markdown";
-      } else {
-        packageType.value = response.packageType || "";
-      }
-
+      fileType.value = response.fileType || "";
       store.setSelectedPackage({
         datasetId,
         version,
         files: [response],
       });
+      const type = (response.fileType || "").toUpperCase();
+      if ([...textFileTypes, ...markdownFileTypes].includes(type)) {
+        loadFileContent(response, datasetId, version);
+      }
     })
     .catch(() => {
-      // Fall back to store data if the endpoint fails
-      fileUri.value = fileData.uri || "";
-      if (isMarkdownFile(fileData.uri)) {
-        packageType.value = "Markdown";
-      } else {
-        packageType.value = fileData.packageType || "";
+      fileType.value = fileData.fileType || "";
+      const type = (fileData.fileType || "").toUpperCase();
+      if ([...textFileTypes, ...markdownFileTypes].includes(type)) {
+        loadFileContent(fileData, datasetId, version);
       }
     })
     .finally(() => {
@@ -146,61 +99,49 @@ onMounted(() => {
     <package-details class="package-details-content" />
 
     <div class="package-viewer">
-      <h3 class="viewer-title">{{ viewerState.type }} Viewer</h3>
-
+      <h3 v-if="isReady" class="viewer-title">File Viewer</h3>
       <div class="viewer-wrapper">
+        <!-- Loading State -->
+        <div v-if="!isReady" class="viewer-message">
+          Loading viewer...
+        </div>
+
         <!-- Timeseries Viewer -->
-        <client-only v-if="viewerState.type === 'timeseries'">
+        <client-only v-else-if="viewerType === 'timeseries'">
           <component :is="TSViewer" v-if="TSViewer" />
           <div v-else class="viewer-message">Loading viewer...</div>
         </client-only>
 
         <!-- Markdown Viewer -->
-        <!-- <div
-          v-else-if="viewerState.type === 'markdown'"
+        <div
+          v-else-if="viewerType === 'markdown'"
           class="markdown-viewer-container"
         >
-          <div v-if="isLoadingContent" class="viewer-message">
-            Loading markdown file...
-          </div>
-          <div
-            v-else-if="contentError"
-            class="viewer-message viewer-message--error"
-          >
-            Error loading file: {{ contentError }}
-          </div>
-          <div v-else class="markdown-viewer">
-            <Markdown :markdownText="fileContent" :disabled="true" />
-          </div>
+          <div v-if="isLoadingContent" class="viewer-message">Loading markdown file...</div>
+          <div v-else-if="contentError" class="viewer-message viewer-message--error">{{ contentError }}</div>
+          <Markdown v-else :markdownText="fileContent" :disabled="true" />
         </div>
--->
+
         <!-- Text/CSV/JSON Viewer -->
-        <!-- <div
-          v-else-if="viewerState.type === 'text'"
+        <div
+          v-else-if="viewerType === 'text'"
           class="text-viewer-container"
         >
-          <div v-if="isLoadingContent" class="viewer-message">
-            Loading text file...
-          </div>
-          <div
-            v-else-if="contentError"
-            class="viewer-message viewer-message--error"
-          >
-            Error loading file: {{ contentError }}
-          </div>
+          <div v-if="isLoadingContent" class="viewer-message">Loading file...</div>
+          <div v-else-if="contentError" class="viewer-message viewer-message--error">{{ contentError }}</div>
           <div v-else class="text-viewer-id">
             <TextViewer
               :content="fileContent"
-              :file-type="viewerState.fileType"
+              :file-type="fileType.toLowerCase()"
               :show-line-numbers="true"
               max-height="70vh"
             />
           </div>
-        </div> -->
+        </div>
 
-        <!-- Status Messages -->
+        <!-- Unsupported -->
         <div v-else class="viewer-message">
-          {{ viewerState.message }}
+          Viewer is not available for this file type.
         </div>
       </div>
     </div>

--- a/pages/package/[id].vue
+++ b/pages/package/[id].vue
@@ -190,12 +190,17 @@ onMounted(() => {
   flex-direction: column;
 }
 
+.package-details-content {
+  margin-bottom: 2rem;
+}
+
 .pennsieve-viewer {
   display: flex;
 }
 
 .package-viewer {
   padding-inline: 2rem;
+  padding-bottom: 4rem;
 }
 
 .viewer-title {

--- a/pages/package/[id].vue
+++ b/pages/package/[id].vue
@@ -253,13 +253,5 @@ onMounted(() => {
 .text-viewer-id {
   width: 100%;
   max-width: 1200px;
-  overflow: auto;
-  border: 1px solid #e1e4e8;
-  border-radius: 8px;
-  padding: 2rem;
-  background-color: #ffffff;
-}
-:deep(.text-viewer__footer) {
-  position: absolute;
 }
 </style>

--- a/pages/package/[id].vue
+++ b/pages/package/[id].vue
@@ -188,16 +188,17 @@ onMounted(() => {
 .package-details {
   display: flex;
   flex-direction: column;
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 24px 2rem 64px;
 }
 
 .package-details-content {
-  margin-bottom: 2rem;
+  margin-bottom: 28px;
 }
 
 .package-viewer {
-  padding-inline: 2rem;
-  padding-bottom: 4rem;
-  margin-top: 2rem;
+  margin-top: 0;
 }
 
 .viewer-title {

--- a/pages/package/[id].vue
+++ b/pages/package/[id].vue
@@ -31,6 +31,7 @@ const timeseriesFileTypes = ["MEF", "EDF", "BDF", "NWB"]
 const csvFileTypes = ["CSV", "TSV"]
 const textFileTypes = ["TXT", "JSON", "XML", "LOG", "YAML", "YML"]
 const markdownFileTypes = ["MD", "MARKDOWN"]
+const imageFileTypes = ["PNG", "JPG", "JPEG", "GIF", "SVG", "WEBP", "BMP", "ICO"]
 
 const isReady = computed(() => !isLoading.value && !!fileType.value)
 
@@ -41,6 +42,7 @@ const viewerType = computed(() => {
   if (csvFileTypes.includes(type)) return "csv"
   if (markdownFileTypes.includes(type)) return "markdown"
   if (textFileTypes.includes(type)) return "text"
+  if (imageFileTypes.includes(type)) return "image"
   return "unsupported"
 })
 
@@ -95,7 +97,7 @@ function fetchFileDetails() {
       if ([...textFileTypes, ...markdownFileTypes].includes(type)) {
         loadFileContent(response, datasetId, version);
       }
-      if (csvFileTypes.includes(type)) {
+      if ([...csvFileTypes, ...imageFileTypes].includes(type)) {
         fetchPresignedUrl(response.path, datasetId, version);
       }
     })
@@ -106,7 +108,7 @@ function fetchFileDetails() {
       if ([...textFileTypes, ...markdownFileTypes].includes(type)) {
         loadFileContent(fileData, datasetId, version);
       }
-      if (csvFileTypes.includes(type)) {
+      if ([...csvFileTypes, ...imageFileTypes].includes(type)) {
         fetchPresignedUrl(fileData.path, datasetId, version);
       }
     })
@@ -175,6 +177,20 @@ onMounted(() => {
           </div>
         </div>
 
+        <!-- Image Viewer -->
+        <div
+          v-else-if="viewerType === 'image'"
+          class="image-viewer-container"
+        >
+          <div v-if="!presignedUrl" class="viewer-message">Loading image...</div>
+          <img
+            v-else
+            :src="presignedUrl"
+            :alt="fileType"
+            class="image-viewer"
+          />
+        </div>
+
         <!-- Unsupported -->
         <div v-else class="viewer-message">
           Viewer is not available for this file type.
@@ -229,11 +245,20 @@ onMounted(() => {
 
 .csv-viewer-container,
 .markdown-viewer-container,
-.text-viewer-container {
+.text-viewer-container,
+.image-viewer-container {
   width: 100%;
 }
 
 .text-viewer-id {
   width: 100%;
+}
+
+.image-viewer {
+  display: block;
+  max-width: 100%;
+  max-height: 70vh;
+  margin: 0 auto;
+  object-fit: contain;
 }
 </style>

--- a/pages/package/[id].vue
+++ b/pages/package/[id].vue
@@ -15,17 +15,11 @@ if (import.meta.client) {
   });
 }
 
-const route = useRoute();
 const runtimeConfig = useRuntimeConfig();
 const store = useMainStore();
-const packageFiles = ref([]);
 const packageType = ref("");
 const fileUri = ref("");
 const isLoading = ref(true);
-
-const PackageFilesUrl = computed(() => {
-  return `${runtimeConfig.public.discover_api_host}/packages/${route.params.id}/files`;
-});
 const viewerState = computed(() => {
   if (!packageType.value) {
     return { type: "processing", message: "Processing package information..." };
@@ -66,45 +60,6 @@ const viewerState = computed(() => {
     message: "Viewer is not available for this file type.",
   };
 });
-
-function getPackageFiles(url) {
-  return useSendXhr(PackageFilesUrl.value, {
-    header: {},
-    method: "GET",
-  })
-    .then((response) => {
-      packageFiles.value = response;
-    })
-    .then(() => {
-      if (packageFiles.value.files.length > 0) {
-        const firstFile = packageFiles.value.files[0];
-        fileUri.value = firstFile.uri;
-
-        // Get DatasetId and version from first file in package
-        const expr = /s3:\/\/[a-z-0-9]+\/([0-9]+)\/(.*)/;
-        const match = firstFile.uri.match(expr);
-        const datasetId = match[1];
-
-        store.setSelectedPackage({
-          datasetId: datasetId,
-          version: 1,
-          files: packageFiles.value.files,
-        });
-
-        // Determine package type
-        if (isMarkdownFile(firstFile.uri)) {
-          packageType.value = "Markdown";
-        } else {
-          packageType.value = firstFile.packageType;
-        }
-
-        packageId.value = firstFile.sourcePackageId;
-      }
-    })
-    .catch(() => {
-      console.log("An error occurred getting the files for the package.");
-    });
-}
 
 // FUNCTIONS HELPER
 function isMarkdownFile(uri) {
@@ -182,11 +137,7 @@ function fetchFileDetails() {
 }
 
 onMounted(() => {
-  if (route.params.id !== "details") {
-    getPackageFiles(PackageFilesUrl);
-  } else {
-    fetchFileDetails();
-  }
+  fetchFileDetails();
 });
 </script>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -996,6 +996,13 @@
   dependencies:
     "@babel/types" "^7.28.5"
 
+"@babel/parser@^7.29.2":
+  version "7.29.2"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.29.2.tgz#58bd50b9a7951d134988a1ae177a35ef9a703ba1"
+  integrity sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==
+  dependencies:
+    "@babel/types" "^7.29.0"
+
 "@babel/plugin-syntax-jsx@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz#2f9beb5eff30fa507c5532d107daac7b888fa34c"
@@ -1056,6 +1063,14 @@
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.28.5"
 
+"@babel/types@^7.29.0":
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.29.0.tgz#9f5b1e838c446e72cf3cd4b918152b8c605e37c7"
+  integrity sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==
+  dependencies:
+    "@babel/helper-string-parser" "^7.27.1"
+    "@babel/helper-validator-identifier" "^7.28.5"
+
 "@cloudflare/kv-asset-handler@^0.4.0":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.1.tgz#717319743437e36c2eaafbb317fdb76b5cff0d88"
@@ -1108,6 +1123,11 @@
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/@ctrl/tinycolor/-/tinycolor-3.6.1.tgz#b6c75a56a1947cc916ea058772d666a2c8932f31"
   integrity sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==
+
+"@ctrl/tinycolor@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@ctrl/tinycolor/-/tinycolor-4.2.0.tgz#ba5d0b917303c0b3d3c14c4865cdc6ded25ac05f"
+  integrity sha512-kzyuwOAQnXJNLS9PSyrk0CWk35nWJW/zl/6KvnTBMFK65gm7U1/Z5BqjxeapjZCIhQcM/DsrEmcbRwDyXyXK4A==
 
 "@duckdb/duckdb-wasm@^1.29.1-dev132.0":
   version "1.30.0"
@@ -1406,6 +1426,18 @@
   resolved "https://registry.yarnpkg.com/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz#8ace5259254426ccef57f3175bc64ed7095ed919"
   integrity sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==
 
+"@lukeed/csprng@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@lukeed/csprng/-/csprng-1.1.0.tgz#1e3e4bd05c1cc7a0b2ddbd8a03f39f6e4b5e6cfe"
+  integrity sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==
+
+"@lukeed/uuid@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@lukeed/uuid/-/uuid-2.0.1.tgz#4f6c34259ee0982a455e1797d56ac27bb040fd74"
+  integrity sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==
+  dependencies:
+    "@lukeed/csprng" "^1.1.0"
+
 "@mapbox/node-pre-gyp@^2.0.0":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@mapbox/node-pre-gyp/-/node-pre-gyp-2.0.2.tgz#bc468667a416c90213c4a670d6e7ab59594b0e9d"
@@ -1427,6 +1459,21 @@
     "@emnapi/core" "^1.5.0"
     "@emnapi/runtime" "^1.5.0"
     "@tybys/wasm-util" "^0.10.1"
+
+"@niivue/niivue@^0.68.1":
+  version "0.68.1"
+  resolved "https://registry.yarnpkg.com/@niivue/niivue/-/niivue-0.68.1.tgz#6eaa8e8698dbcb03e0bb850452307d7059cf64ff"
+  integrity sha512-uZ/4pJ6mGk8UY8DWOu+/cC/AOpPQW7W6kEhyOrEhuUDZW5+lPmmcnqU6ilipiR4iAcSA8r9KTXJm+p55iTyUgw==
+  dependencies:
+    "@lukeed/uuid" "^2.0.1"
+    "@ungap/structured-clone" "^1.2.0"
+    array-equal "^1.0.2"
+    fflate "^0.8.2"
+    gl-matrix "^3.4.3"
+    nifti-reader-js "^0.8.0"
+    zarrita "^0.5.0"
+  optionalDependencies:
+    "@rollup/rollup-linux-x64-gnu" "^4.18.1"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -2061,6 +2108,20 @@
     "@parcel/watcher-win32-ia32" "2.5.1"
     "@parcel/watcher-win32-x64" "2.5.1"
 
+"@pennsieve-viz/core@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@pennsieve-viz/core/-/core-0.3.0.tgz#5e5ff7581b4196375257a0d9b7268a9e3ba145ac"
+  integrity sha512-+KOTzbssc3Cbe+Xx996L1B+WyWLU1cTUsfNIieUmp2H0cSI3lZcH5QFhmSL1uYuJEwwEgqxhwr2YOGicCq/0pw==
+  dependencies:
+    "@element-plus/icons-vue" "^2.3.1"
+    "@niivue/niivue" "^0.68.1"
+    d3 "^7.9.0"
+    dompurify "^3.2.6"
+    element-plus "^2.3.0"
+    hyparquet "^1.12.1"
+    marked "^15.0.7"
+    ramda "^0.31.3"
+
 "@pinia-plugin-persistedstate/nuxt@^1.2.0":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@pinia-plugin-persistedstate/nuxt/-/nuxt-1.2.1.tgz#15f7c3d172bd6320f6017d9ccf785019a7de1060"
@@ -2327,6 +2388,11 @@
   version "4.53.3"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.53.3.tgz#fd0dea3bb9aa07e7083579f25e1c2285a46cb9fa"
   integrity sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==
+
+"@rollup/rollup-linux-x64-gnu@^4.18.1":
+  version "4.60.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz#56a6a0d9076f2a05a976031493b24a20ddcc0e77"
+  integrity sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==
 
 "@rollup/rollup-linux-x64-musl@4.53.3":
   version "4.53.3"
@@ -2992,6 +3058,16 @@
   resolved "https://registry.yarnpkg.com/@types/web-bluetooth/-/web-bluetooth-0.0.16.tgz#1d12873a8e49567371f2a75fe3e7f7edca6662d8"
   integrity sha512-oh8q2Zc32S6gd/j50GowEjKLoOVOwHP/bWVjKJInBwQqdOYMdPrf1oVlelTlyfFK3CKxL1uahMDAr+vy8T7yMQ==
 
+"@types/web-bluetooth@^0.0.20":
+  version "0.0.20"
+  resolved "https://registry.yarnpkg.com/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz#f066abfcd1cbe66267cdbbf0de010d8a41b41597"
+  integrity sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==
+
+"@ungap/structured-clone@^1.2.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.3.0.tgz#d06bbb384ebcf6c505fde1c3d0ed4ddffe0aaff8"
+  integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
+
 "@unhead/vue@^2.0.19":
   version "2.0.19"
   resolved "https://registry.yarnpkg.com/@unhead/vue/-/vue-2.0.19.tgz#d628b88526c1e92bb960b2997fdd676b279fe6d9"
@@ -3117,6 +3193,17 @@
     estree-walker "^2.0.2"
     source-map-js "^1.2.1"
 
+"@vue/compiler-core@3.5.32":
+  version "3.5.32"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.5.32.tgz#5115ca099b04fedd8f623f93b522d914c376cbeb"
+  integrity sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ==
+  dependencies:
+    "@babel/parser" "^7.29.2"
+    "@vue/shared" "3.5.32"
+    entities "^7.0.1"
+    estree-walker "^2.0.2"
+    source-map-js "^1.2.1"
+
 "@vue/compiler-dom@3.5.13":
   version "3.5.13"
   resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.5.13.tgz#bb1b8758dbc542b3658dda973b98a1c9311a8a58"
@@ -3132,6 +3219,14 @@
   dependencies:
     "@vue/compiler-core" "3.5.25"
     "@vue/shared" "3.5.25"
+
+"@vue/compiler-dom@3.5.32":
+  version "3.5.32"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.5.32.tgz#6069eae2f0d1a38263e9445f3c1da1a06e5f6534"
+  integrity sha512-ybHAu70NtiEI1fvAUz3oXZqkUYEe5J98GjMDpTGl5iHb0T15wQYLR4wE3h9xfuTNA+Cm2f4czfe8B4s+CCH57Q==
+  dependencies:
+    "@vue/compiler-core" "3.5.32"
+    "@vue/shared" "3.5.32"
 
 "@vue/compiler-sfc@3.5.13":
   version "3.5.13"
@@ -3163,6 +3258,21 @@
     postcss "^8.5.6"
     source-map-js "^1.2.1"
 
+"@vue/compiler-sfc@3.5.32":
+  version "3.5.32"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.5.32.tgz#1f4bef6d4fbfc0cb8278a08d08c05a3afddbd2c8"
+  integrity sha512-8UYUYo71cP/0YHMO814TRZlPuUUw3oifHuMR7Wp9SNoRSrxRQnhMLNlCeaODNn6kNTJsjFoQ/kqIj4qGvya4Xg==
+  dependencies:
+    "@babel/parser" "^7.29.2"
+    "@vue/compiler-core" "3.5.32"
+    "@vue/compiler-dom" "3.5.32"
+    "@vue/compiler-ssr" "3.5.32"
+    "@vue/shared" "3.5.32"
+    estree-walker "^2.0.2"
+    magic-string "^0.30.21"
+    postcss "^8.5.8"
+    source-map-js "^1.2.1"
+
 "@vue/compiler-ssr@3.5.13":
   version "3.5.13"
   resolved "https://registry.yarnpkg.com/@vue/compiler-ssr/-/compiler-ssr-3.5.13.tgz#e771adcca6d3d000f91a4277c972a996d07f43ba"
@@ -3178,6 +3288,14 @@
   dependencies:
     "@vue/compiler-dom" "3.5.25"
     "@vue/shared" "3.5.25"
+
+"@vue/compiler-ssr@3.5.32":
+  version "3.5.32"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-ssr/-/compiler-ssr-3.5.32.tgz#5632a0934cb58cf88dcff1404ecf06b5a16f6816"
+  integrity sha512-Gp4gTs22T3DgRotZ8aA/6m2jMR+GMztvBXUBEUOYOcST+giyGWJ4WvFd7QLHBkzTxkfOt8IELKNdpzITLbA2rw==
+  dependencies:
+    "@vue/compiler-dom" "3.5.32"
+    "@vue/shared" "3.5.32"
 
 "@vue/devtools-api@^6.6.3", "@vue/devtools-api@^6.6.4":
   version "6.6.4"
@@ -3243,6 +3361,13 @@
   dependencies:
     "@vue/shared" "3.5.25"
 
+"@vue/reactivity@3.5.32":
+  version "3.5.32"
+  resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.5.32.tgz#a4cb973095eade1ae6d899ae60ba9019d2bd21f5"
+  integrity sha512-/ORasxSGvZ6MN5gc+uE364SxFdJ0+WqVG0CENXaGW58TOCdrAW76WWaplDtECeS1qphvtBZtR+3/o1g1zL4xPQ==
+  dependencies:
+    "@vue/shared" "3.5.32"
+
 "@vue/runtime-core@3.5.13":
   version "3.5.13"
   resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.5.13.tgz#1fafa4bf0b97af0ebdd9dbfe98cd630da363a455"
@@ -3258,6 +3383,14 @@
   dependencies:
     "@vue/reactivity" "3.5.25"
     "@vue/shared" "3.5.25"
+
+"@vue/runtime-core@3.5.32":
+  version "3.5.32"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.5.32.tgz#7ab8bc83210886aa4db69e5d72f31188628fe9d4"
+  integrity sha512-pDrXCejn4UpFDFmMd27AcJEbHaLemaE5o4pbb7sLk79SRIhc6/t34BQA7SGNgYtbMnvbF/HHOftYBgFJtUoJUQ==
+  dependencies:
+    "@vue/reactivity" "3.5.32"
+    "@vue/shared" "3.5.32"
 
 "@vue/runtime-dom@3.5.13":
   version "3.5.13"
@@ -3279,6 +3412,16 @@
     "@vue/shared" "3.5.25"
     csstype "^3.1.3"
 
+"@vue/runtime-dom@3.5.32":
+  version "3.5.32"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-dom/-/runtime-dom-3.5.32.tgz#fe7815b25e55df34c6ae82a0d06be79d1342d7cf"
+  integrity sha512-1CDVv7tv/IV13V8Nip1k/aaObVbWqRlVCVezTwx3K07p7Vxossp5JU1dcPNhJk3w347gonIUT9jQOGutyJrSVQ==
+  dependencies:
+    "@vue/reactivity" "3.5.32"
+    "@vue/runtime-core" "3.5.32"
+    "@vue/shared" "3.5.32"
+    csstype "^3.2.3"
+
 "@vue/server-renderer@3.5.13":
   version "3.5.13"
   resolved "https://registry.yarnpkg.com/@vue/server-renderer/-/server-renderer-3.5.13.tgz#429ead62ee51de789646c22efe908e489aad46f7"
@@ -3295,6 +3438,14 @@
     "@vue/compiler-ssr" "3.5.25"
     "@vue/shared" "3.5.25"
 
+"@vue/server-renderer@3.5.32":
+  version "3.5.32"
+  resolved "https://registry.yarnpkg.com/@vue/server-renderer/-/server-renderer-3.5.32.tgz#74579f65d271e217bdef0df62474b3c8a8dba55b"
+  integrity sha512-IOjm2+JQwRFS7W28HNuJeXQle9KdZbODFY7hFGVtnnghF51ta20EWAZJHX+zLGtsHhaU6uC9BGPV52KVpYryMQ==
+  dependencies:
+    "@vue/compiler-ssr" "3.5.32"
+    "@vue/shared" "3.5.32"
+
 "@vue/shared@3.5.13":
   version "3.5.13"
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.5.13.tgz#87b309a6379c22b926e696893237826f64339b6f"
@@ -3304,6 +3455,21 @@
   version "3.5.25"
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.5.25.tgz#21edcff133a5a04f72c4e4c6142260963fe5afbe"
   integrity sha512-AbOPdQQnAnzs58H2FrrDxYj/TJfmeS2jdfEEhgiKINy+bnOANmVizIEgq1r+C5zsbs6l1CCQxtcj71rwNQ4jWg==
+
+"@vue/shared@3.5.32":
+  version "3.5.32"
+  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.5.32.tgz#dd8ba0d709bf3f758c324a81c8897bad5e1540cf"
+  integrity sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg==
+
+"@vueuse/core@12.0.0":
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/@vueuse/core/-/core-12.0.0.tgz#9b07923ca24a6b5873bf614888c7d0f796cef7d2"
+  integrity sha512-C12RukhXiJCbx4MGhjmd/gH52TjJsc3G0E0kQj/kb19H3Nt6n1CA4DRWuTdWWcaFRdlTe0npWDS942mvacvNBw==
+  dependencies:
+    "@types/web-bluetooth" "^0.0.20"
+    "@vueuse/metadata" "12.0.0"
+    "@vueuse/shared" "12.0.0"
+    vue "^3.5.13"
 
 "@vueuse/core@^9.1.0":
   version "9.13.0"
@@ -3315,10 +3481,22 @@
     "@vueuse/shared" "9.13.0"
     vue-demi "*"
 
+"@vueuse/metadata@12.0.0":
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/@vueuse/metadata/-/metadata-12.0.0.tgz#ba6c279528fdb3c821825302f8a45c5ce327db01"
+  integrity sha512-Yzimd1D3sjxTDOlF05HekU5aSGdKjxhuhRFHA7gDWLn57PRbBIh+SF5NmjhJ0WRgF3my7T8LBucyxdFJjIfRJQ==
+
 "@vueuse/metadata@9.13.0":
   version "9.13.0"
   resolved "https://registry.yarnpkg.com/@vueuse/metadata/-/metadata-9.13.0.tgz#bc25a6cdad1b1a93c36ce30191124da6520539ff"
   integrity sha512-gdU7TKNAUVlXXLbaF+ZCfte8BjRJQWPCa2J55+7/h+yDtzw3vOoGQDRXzI6pyKyo6bXFT5/QoPE4hAknExjRLQ==
+
+"@vueuse/shared@12.0.0":
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/@vueuse/shared/-/shared-12.0.0.tgz#8d765a1c5038cc4ea29e9bbb622b2d4fd3365aef"
+  integrity sha512-3i6qtcq2PIio5i/vVYidkkcgvmTjCqrf26u+Fd4LhnbBmIT6FN8y6q/GJERp8lfcB9zVEfjdV0Br0443qZuJpw==
+  dependencies:
+    vue "^3.5.13"
 
 "@vueuse/shared@9.13.0":
   version "9.13.0"
@@ -3326,6 +3504,14 @@
   integrity sha512-UrnhU+Cnufu4S6JLCPZnkWh0WwZGUp72ktOF2DFptMlOs3TOdVv8xJN53zhHGARmVOsz5KqOls09+J1NR6sBKw==
   dependencies:
     vue-demi "*"
+
+"@zarrita/storage@^0.1.3":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@zarrita/storage/-/storage-0.1.4.tgz#05d7d1d43fc0163d22a17356b619ffeb1ed223d7"
+  integrity sha512-qURfJAQcQGRfDQ4J9HaCjGaj3jlJKc66bnRk6G/IeLUsM7WKyG7Bzsuf1EZurSXyc0I4LVcu6HaeQQ4d3kZ16g==
+  dependencies:
+    reference-spec-reader "^0.2.0"
+    unzipit "1.4.3"
 
 abbrev@^4.0.0:
   version "4.0.0"
@@ -3470,6 +3656,11 @@ array-back@^6.2.2:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/array-back/-/array-back-6.2.2.tgz#f567d99e9af88a6d3d2f9dfcc21db6f9ba9fd157"
   integrity sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==
+
+array-equal@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.2.tgz#a8572e64e822358271250b9156d20d96ef5dec04"
+  integrity sha512-gUHx76KtnhEgB3HOuFYiCm3FIdEs6ocM2asHvNTkfu/Y09qQVrrVVaOKENmS2KkSaGoxgXNqC+ZVtR/n0MOkSA==
 
 ast-kit@^2.1.2, ast-kit@^2.1.3:
   version "2.2.0"
@@ -4091,7 +4282,7 @@ cssstyle@^4.0.1:
     "@asamuzakjp/css-color" "^3.2.0"
     rrweb-cssom "^0.8.0"
 
-csstype@^3.1.3:
+csstype@^3.1.3, csstype@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.2.3.tgz#ec48c0f3e993e50648c86da559e2610995cf989a"
   integrity sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==
@@ -4540,6 +4731,27 @@ electron-to-chromium@^1.5.249:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.260.tgz#73f555d3e9b9fd16ff48fc406bbad84efa9b86c7"
   integrity sha512-ov8rBoOBhVawpzdre+Cmz4FB+y66Eqrk6Gwqd8NGxuhv99GQ8XqMAr351KEkOt7gukXWDg6gJWEMKgL2RLMPtA==
 
+element-plus@^2.3.0:
+  version "2.13.6"
+  resolved "https://registry.yarnpkg.com/element-plus/-/element-plus-2.13.6.tgz#965a38dce9638538e6056e1908e184cabe95b9f0"
+  integrity sha512-XHgwXr8Fjz6i+6BaqFhAbae/dJbG7bBAAlHrY3pWL7dpj+JcqcOyKYt4Oy5KP86FQwS1k4uIZDjCx2FyUR5lDg==
+  dependencies:
+    "@ctrl/tinycolor" "^4.2.0"
+    "@element-plus/icons-vue" "^2.3.2"
+    "@floating-ui/dom" "^1.0.1"
+    "@popperjs/core" "npm:@sxzz/popperjs-es@^2.11.7"
+    "@types/lodash" "^4.17.20"
+    "@types/lodash-es" "^4.17.12"
+    "@vueuse/core" "12.0.0"
+    async-validator "^4.2.5"
+    dayjs "^1.11.19"
+    lodash "^4.17.23"
+    lodash-es "^4.17.23"
+    lodash-unified "^1.0.3"
+    memoize-one "^6.0.0"
+    normalize-wheel-es "^1.2.0"
+    vue-component-type-helpers "^3.2.4"
+
 element-plus@^2.9.0:
   version "2.12.0"
   resolved "https://registry.yarnpkg.com/element-plus/-/element-plus-2.12.0.tgz#489192aae6e2f08f0c78ac41c0115f8231e8c8c3"
@@ -4592,6 +4804,11 @@ entities@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-6.0.1.tgz#c28c34a43379ca7f61d074130b2f5f7020a30694"
   integrity sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==
+
+entities@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-7.0.1.tgz#26e8a88889db63417dcb9a1e79a3f1bc92b5976b"
+  integrity sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==
 
 error-stack-parser-es@^1.0.5:
   version "1.0.5"
@@ -4818,6 +5035,11 @@ fdir@^6.2.0, fdir@^6.5.0:
   resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
   integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
 
+fflate@^0.8.0, fflate@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.8.2.tgz#fc8631f5347812ad6028bbe4a2308b2792aa1dea"
+  integrity sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==
+
 file-uri-to-path@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
@@ -4976,6 +5198,11 @@ git-url-parse@^16.0.1:
   integrity sha512-cPLz4HuK86wClEW7iDdeAKcCVlWXmrLpb2L+G9goW0Z1dtpNS6BXXSOckUTlJT/LDQViE1QZKstNORzHsLnobw==
   dependencies:
     git-up "^8.1.0"
+
+gl-matrix@^3.4.3:
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/gl-matrix/-/gl-matrix-3.4.4.tgz#7789ee4982f62c7a7af447ee488f3bd6b0c77003"
+  integrity sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==
 
 glob-parent@^5.1.2:
   version "5.1.2"
@@ -5539,6 +5766,11 @@ lodash-es@^4.17.21:
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.22.tgz#eb7d123ec2470d69b911abe34f85cb694849b346"
   integrity sha512-XEawp1t0gxSi9x01glktRZ5HDy0HXqrM0x5pXQM98EaI0NxO6jVM7omDOxsuEo5UIASAnm2bRp1Jt/e0a2XU8Q==
 
+lodash-es@^4.17.23:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.18.1.tgz#b962eeb80d9d983a900bf342961fb7418ca10b1d"
+  integrity sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==
+
 lodash-unified@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/lodash-unified/-/lodash-unified-1.0.3.tgz#80b1eac10ed2eb02ed189f08614a29c27d07c894"
@@ -5583,6 +5815,11 @@ lodash@^4.17.15, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
+lodash@^4.17.23:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 long@^5.0.0:
   version "5.3.2"
@@ -5827,6 +6064,13 @@ napi-wasm@^1.1.0:
   resolved "https://registry.yarnpkg.com/napi-wasm/-/napi-wasm-1.1.3.tgz#7bb95c88e6561f84880bb67195437b1cfbe99224"
   integrity sha512-h/4nMGsHjZDCYmQVNODIrYACVJ+I9KItbG+0si6W/jSjdA9JbWDoU4LLeMXVcEQGHjttI2tuXqDrbGF7qkUHHg==
 
+nifti-reader-js@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/nifti-reader-js/-/nifti-reader-js-0.8.0.tgz#3aa2109e0139d89e625fdaba6d9ada1bd59a903a"
+  integrity sha512-iO1iIhQDfKniy+l/86HfOPte7So+SxBmBiMSiUB2VXU7z4hSewMTlE3h0fCgfzfXvMUa+ilzLTJ2ZHmtFw6EWw==
+  dependencies:
+    fflate "^0.8.2"
+
 nitropack@^2.12.9:
   version "2.12.9"
   resolved "https://registry.yarnpkg.com/nitropack/-/nitropack-2.12.9.tgz#2c92765440f980d27a8c3b378f3a850e66157ce4"
@@ -5983,6 +6227,13 @@ nth-check@^2.0.1:
   integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
   dependencies:
     boolbase "^1.0.0"
+
+numcodecs@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/numcodecs/-/numcodecs-0.3.2.tgz#09887cfc2a3ae1c59a495c01a7f0528118d85dcd"
+  integrity sha512-6YSPnmZgg0P87jnNhi3s+FVLOcIn3y+1CTIgUulA3IdASzK9fJM87sUFkpyA+be9GibGRaST2wCgkD+6U+fWKw==
+  dependencies:
+    fflate "^0.8.0"
 
 nuxt-site-config-kit@2.2.21, nuxt-site-config-kit@^2.2.15:
   version "2.2.21"
@@ -6612,6 +6863,15 @@ postcss@^8.4.48, postcss@^8.5.6:
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 
+postcss@^8.5.8:
+  version "8.5.9"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.9.tgz#f6ee9e0b94f0f19c97d2f172bfbd7fc71fe1cca4"
+  integrity sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==
+  dependencies:
+    nanoid "^3.3.11"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
+
 pretty-bytes@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-7.1.0.tgz#d788c9906241dbdcd4defab51b6d7470243db9bd"
@@ -6794,6 +7054,11 @@ redis-parser@^3.0.0:
   integrity sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==
   dependencies:
     redis-errors "^1.0.0"
+
+reference-spec-reader@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/reference-spec-reader/-/reference-spec-reader-0.2.0.tgz#52bd79614dde68e68f05c97a05ae04ff20acd7ec"
+  integrity sha512-q0mfCi5yZSSHXpCyxjgQeaORq3tvDsxDyzaadA/5+AbAUwRyRuuTh0aRQuE/vAOt/qzzxidJ5iDeu1cLHaNBlQ==
 
 regexp-tree@^0.1.27:
   version "0.1.27"
@@ -7717,6 +7982,13 @@ unwasm@^0.3.11:
     pkg-types "^2.2.0"
     unplugin "^2.3.6"
 
+unzipit@1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/unzipit/-/unzipit-1.4.3.tgz#738298a6b235892bf7ce7db82cff813d4ca664ac"
+  integrity sha512-gsq2PdJIWWGhx5kcdWStvNWit9FVdTewm4SEG7gFskWs+XCVaULt9+BwuoBtJiRE8eo3L1IPAOrbByNLtLtIlg==
+  dependencies:
+    uzip-module "^1.0.2"
+
 update-browserslist-db@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.1.4.tgz#7802aa2ae91477f255b86e0e46dbc787a206ad4a"
@@ -7752,6 +8024,11 @@ uuid@^9.0.1:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
   integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
+
+uzip-module@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/uzip-module/-/uzip-module-1.0.3.tgz#6bbabe2a3efea5d5a4a47479f523a571de3427ce"
+  integrity sha512-AMqwWZaknLM77G+VPYNZLEruMGWGzyigPK3/Whg99B3S6vGHuqsyl5ZrOv1UUF3paGK1U6PM0cnayioaryg/fA==
 
 vite-dev-rpc@^1.1.0:
   version "1.1.0"
@@ -7848,6 +8125,11 @@ vue-chartjs@^5.3.0:
   resolved "https://registry.yarnpkg.com/vue-chartjs/-/vue-chartjs-5.3.3.tgz#1ee3e1580bb35779616f881eaf56711aee9e1c85"
   integrity sha512-jqxtL8KZ6YJ5NTv6XzrzLS7osyegOi28UGNZW0h9OkDL7Sh1396ht4Dorh04aKrl2LiSalQ84WtqiG0RIJb0tA==
 
+vue-component-type-helpers@^3.2.4:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/vue-component-type-helpers/-/vue-component-type-helpers-3.2.6.tgz#49976f7ad879df75d884cf156b8a068a6f9a8f65"
+  integrity sha512-O02tnvIfOQVmnvoWwuSydwRoHjZVt8UEBR+2p4rT35p8GAy5VTlWP8o5qXfJR/GWCN0nVZoYWsVUvx2jwgdBmQ==
+
 vue-demi@*, vue-demi@^0.14.10:
   version "0.14.10"
   resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.14.10.tgz#afc78de3d6f9e11bf78c55e8510ee12814522f04"
@@ -7887,6 +8169,17 @@ vue@3.5.13:
     "@vue/runtime-dom" "3.5.13"
     "@vue/server-renderer" "3.5.13"
     "@vue/shared" "3.5.13"
+
+vue@^3.5.13:
+  version "3.5.32"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-3.5.32.tgz#9a7cbeb181aa4b2a71c3ebac4995542cf0353de3"
+  integrity sha512-vM4z4Q9tTafVfMAK7IVzmxg34rSzTFMyIe0UUEijUCkn9+23lj0WRfA83dg7eQZIUlgOSGrkViIaCfqSAUXsMw==
+  dependencies:
+    "@vue/compiler-dom" "3.5.32"
+    "@vue/compiler-sfc" "3.5.32"
+    "@vue/runtime-dom" "3.5.32"
+    "@vue/server-renderer" "3.5.32"
+    "@vue/shared" "3.5.32"
 
 vue@^3.5.23:
   version "3.5.25"
@@ -8073,6 +8366,14 @@ youch@^4.1.0-beta.11, youch@^4.1.0-beta.12:
     "@speed-highlight/core" "^1.2.9"
     cookie-es "^2.0.0"
     youch-core "^0.3.3"
+
+zarrita@^0.5.0:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/zarrita/-/zarrita-0.5.4.tgz#b64a323c6f6c33e7f3cf741f70d5f48b31a7fb5a"
+  integrity sha512-i88iN2+HqIQ+uiCEWLfhjbYNXAJD7IrM4h3lFwFclfqEOOhxp10amRWtqmgN5jbuy3+h0LwdyLVVzk4y9rTLgg==
+  dependencies:
+    "@zarrita/storage" "^0.1.3"
+    numcodecs "^0.3.2"
 
 zip-stream@^6.0.1:
   version "6.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2108,10 +2108,10 @@
     "@parcel/watcher-win32-ia32" "2.5.1"
     "@parcel/watcher-win32-x64" "2.5.1"
 
-"@pennsieve-viz/core@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@pennsieve-viz/core/-/core-0.3.0.tgz#5e5ff7581b4196375257a0d9b7268a9e3ba145ac"
-  integrity sha512-+KOTzbssc3Cbe+Xx996L1B+WyWLU1cTUsfNIieUmp2H0cSI3lZcH5QFhmSL1uYuJEwwEgqxhwr2YOGicCq/0pw==
+"@pennsieve-viz/core@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@pennsieve-viz/core/-/core-0.3.1.tgz#9a16f8dec36aa177a5c4a1aa91ca0a10c4675ccc"
+  integrity sha512-qJ3VMZb84frnXa+kM1VWJwNZi1tu+2GhpfAKzrLiKYEqfct3uM8CHLqtFxLifcTYrpUMwM8mHczArv9cZ62jeg==
   dependencies:
     "@element-plus/icons-vue" "^2.3.1"
     "@niivue/niivue" "^0.68.1"


### PR DESCRIPTION



# Changelog — `fix_file-viewer` → `main`

> Rewrites the package details file viewer on `@pennsieve-viz/core`, adds an image viewer, and improves file-list navigation.

## Screenshots

  <table>                                                                                                                                                                                    
    <tr>                                                                                                                                                                                     
      <td width="50%">                                                                                                                                                                       
        <p align="center"><strong>Image viewer</strong></p>                                                                                                                                  
        <img alt="Image_viewer_ES" src="https://github.com/user-attachments/assets/9fa428a8-7ed3-4ec9-917e-e1a479406558" width="100%" />                                                     
      </td>                                                                                                                                                                                  
      <td width="50%">                                                                                                                                                                     
        <p align="center"><strong>Markdown viewer</strong></p>                                                                                                                               
        <img alt="markdown_viewer_ES" src="https://github.com/user-attachments/assets/78a745e4-bd44-4282-9e6e-827a6d5fa066" width="100%" />                                                
      </td>                                                                                                                                                                                  
    </tr>
    <tr>                                                                                                                                                                                     
      <td width="50%" colspan="2">                                                                                                                                                           
        <p align="center"><strong>TSV viewer</strong></p>
        <img alt="tsv_viewer_ES" src="https://github.com/user-attachments/assets/48d53af8-a7be-42f4-bbb0-6ffd9f6e48a0" width="100%" />                                                       
      </td>                                                                                                                                                                                  
    </tr>                                                                                                                                                                                    
  </table>                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                                                    

  <table>
    <tr>
      <td width="50%">
        <p align="center"><strong>JSON Viewer</strong></p>
        <video src="https://github.com/user-attachments/assets/c1032caa-6e53-44e5-97a7-3be2a1fddd86" controls width="100%"></video>                                                          
      </td>                                                                                                                                                                                  
      <td width="50%">                                                                                                                                                                       
        <p align="center"><strong>File navigation</strong></p>                                                                                                                                        
        <video src="https://github.com/user-attachments/assets/d26e6f40-f248-4667-b4c5-36705d330ba9" controls width="100%"></video>                                                        
      </td>                                                                                                                                                                                  
    </tr>                                                                                                                                                                                  
  </table>                                                                                                                                                                                   
              

## Summary

- Migrates the package-details viewer from `pennsieve-visualization` to `@pennsieve-viz/core`.
- Replaces URI-extension sniffing with a file-type-driven viewer router.
- Adds a native **image viewer** for common web-renderable formats.
- Simplifies `PackageDetails` (removes the zip/archive download form; keeps the single-file presigned download).
- Adds deep-link / "Back to files" support between the file list and the package page.

## Viewer matrix

| Viewer       | File types                                              | Render path                                    |
| ------------ | ------------------------------------------------------- | ---------------------------------------------- |
| Timeseries   | `MEF`, `EDF`, `BDF`, `NWB`                              | `tsviewer` (client-only dynamic import)        |
| CSV          | `CSV`, `TSV`                                            | `CSVViewer` via presigned URL, 25 rows/page    |
| Markdown     | `MD`, `MARKDOWN`                                        | `Markdown` via `useFileContent`                |
| Text         | `TXT`, `JSON`, `XML`, `LOG`, `YAML`, `YML`              | `TextViewer` via `useFileContent`              |
| **Image** *(new)* | `PNG`, `JPG`, `JPEG`, `GIF`, `SVG`, `WEBP`, `BMP`, `ICO` | Native `<img>` via presigned URL              |

> `TIFF` / `TIF` intentionally excluded — not natively renderable in `<img>`; would need a decoder (e.g. `tiff.js`, `UTIF`) or server-side conversion.

## Changes

### `pages/package/[id].vue` — full rewrite

**Removed**

- `pennsieve-visualization` imports (`Markdown`, `TextViewer`).
- `/packages/{id}/files` fetch flow driven by `route.params.id`.
- URI-sniffing helpers: `isMarkdownFile`, `isTextFile`, `getFileType`.
- Previously commented-out Markdown / Text viewer blocks.

**Added / changed**

- Imports `Markdown`, `TextViewer`, `CSVViewer` (and stylesheet) from `@pennsieve-viz/core`.
- New reactive state: `fileType`, `fileUri`, `presignedUrl`, `fileContent`, `isLoadingContent`, `contentError`.
- Single `isReady` / `viewerType` computed drives the render.
- File lookup now hits `/datasets/{datasetId}/versions/{version}/files?path=...` using `selectedPackage` from the store, falling back to the stored file data on error.
- Presigned URLs fetched via `/files/download-manifest` for CSV and image viewers.
- Text / Markdown content loaded via `useFileContent().fetchFileContent`.
- Viewer title reads "File Viewer" and only appears once the file is ready.
- Styling overhaul:
  - Centered layout (`max-width: 1280px`)
  - Smaller uppercase title
  - Unified container widths
  - Image constrained to `max-height: 70vh` with `object-fit: contain`
  - Removed bordered card around the text viewer

### `components/Dataset/PackageDetails/PackageDetails.vue`

- Replaced "Back to dataset" with **"Back to files"** — navigates to `datasets-datasetId#files` and preserves the parent folder via `?path=...` (new `parentFolderPath` / `backToFilesRoute` computeds).
- Removed the zip/archive download form and `executeDownload` / `archiveName` / `zipFormRef` machinery; `downloadFile` (single presigned-URL download) is now the only path.
- Removed unused helpers: `headerContent`, `zipitUrl`, `zipData`, `formatType`, `formatHeader`, `sizeString`, `onDownloadClick`.
- Layout simplified: an action row replaces the `container-fluid` / `row` grid structure.

### `components/Datasets/DatasetFiles/DatasetFiles.vue`

- Reads the initial folder from `route.query.path` on mount — deep links into subfolders now resolve.
- Folder-click no longer passes the folder `name` as a second arg to `getDatasetFiles`.
- Route params for opening a file use `sourcePackageId` when present, otherwise fall back to the file `name` (instead of the literal `"details"`).

### Dependencies

- `package.json` / `yarn.lock`: adds **`@pennsieve-viz/core@^0.3.1`**.

## Test plan

- [ ] Open a package with each supported file type and confirm the correct viewer renders.
- [ ] Open an image file (`PNG`, `JPG`, `SVG`, `WEBP`, etc.) and confirm it renders, is centered, and respects the 70vh cap.
- [ ] Open an unsupported type and confirm the fallback message renders.
- [ ] Navigate into a subfolder, open a file, then click **Back to files** — confirm it returns to the same subfolder.
- [ ] Click **Download File** on a package and confirm the presigned download works.
- [ ] Deep-link to `/datasets/{id}?path=foo/bar#files` and confirm it lands in the correct folder.
