### PR TITLE
update peer dependencies and config and add CDEs link

### DIFF
--- a/components/AppHeader/AppHeader.vue
+++ b/components/AppHeader/AppHeader.vue
@@ -15,8 +15,8 @@
           <li><nuxt-link to="/data?type=dataset">Data</nuxt-link></li>
           <li><nuxt-link to="/projects">Projects</nuxt-link></li>
           <li><nuxt-link to="/dashboard">Dashboard</nuxt-link></li>
-          <li><a href="https://cde.epilepsy.science" target="_blank" rel="noopener">CDE's</a></li>
           <li><nuxt-link to="/about">About</nuxt-link></li>
+          <li><a class="cde-link" href="https://cde.epilepsy.science" target="_blank" rel="noopener"><strong>CDE's</strong> <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: middle; margin-left: 2px;"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg></a></li>
         </ul>
       </nav>
     </div>
@@ -115,6 +115,22 @@ onBeforeUnmount(() => {
     width: 0;
     background-color: #297FCA;
     transition: width 0.4s ease;
+  }
+}
+
+.header-nav a.cde-link {
+  background-color: #297fca;
+  color: #ffffff;
+  border-radius: 4px;
+  text-transform: none;
+  transition: background-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+
+  &:hover,
+  &:focus-visible {
+    color: #ffffff;
+    background-color: #1a5a9e;
+    transform: scale(1.05);
+    box-shadow: 0 2px 8px rgba(41, 127, 202, 0.4);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -36,8 +36,9 @@
     "isomorphic-dompurify": "^1.9.0",
     "lodash": "^4.17.21",
     "marked": "^8.0.1",
-    "pennsieve-dashboard": "^1.0.0",
-    "pennsieve-ui-library": "1.0.6",
+    "moment": "^2.30.1",
+    "pennsieve-dashboard": "1.0.2",
+    "pennsieve-ui-library": "1.0.8",
     "pennsieve-visualization": "0.6.5",
     "pinia": "^3.0.4",
     "ramda": "^0.29.0",
@@ -46,8 +47,5 @@
     "vue-recaptcha-v3": "^2.0.1",
     "vue-social-sharing": "^4.0.0-alpha4"
   },
-  "type": "module",
-  "resolutions": {
-    "vue": "3.5.32"
-  }
+  "type": "module"
 }

--- a/plugins/element-plus.js
+++ b/plugins/element-plus.js
@@ -1,6 +1,8 @@
-import ElementPlus from 'element-plus'
+import ElementPlus, { ID_INJECTION_KEY, ZINDEX_INJECTION_KEY } from 'element-plus'
 import 'element-plus/dist/index.css'
 
 export default defineNuxtPlugin((nuxtApp) => {
   nuxtApp.vueApp.use(ElementPlus)
+  nuxtApp.vueApp.provide(ID_INJECTION_KEY, { prefix: 1024, current: 0 })
+  nuxtApp.vueApp.provide(ZINDEX_INJECTION_KEY, { current: 0 })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -6424,27 +6424,20 @@ pathe@^2.0.1, pathe@^2.0.3:
   resolved "https://registry.yarnpkg.com/pathe/-/pathe-2.0.3.tgz#3ecbec55421685b70a9da872b2cff3e1cbed1716"
   integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
 
-pennsieve-dashboard@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/pennsieve-dashboard/-/pennsieve-dashboard-1.0.0.tgz#4bf48c3f5939fa819057d635cf5a551f06641731"
-  integrity sha512-mgp2HtqfjSTBZ9LS1s4KP19FiPRXkeRheI7nrtD3X4vSybxfUZeJdJKrH9xaFiZ0cHh8t3vkuM5eO1n5DQ0Zwg==
+pennsieve-dashboard@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pennsieve-dashboard/-/pennsieve-dashboard-1.0.2.tgz#12f00f93f5225a0a1b7b96115b62dd619b4a4cf7"
+  integrity sha512-zjIHx/cHXRqY34qnap4MYb4kF4tyH0Z6aa1j/esTZwOYgixTh8o8SAEWhdco9ogkVnlOaORdvreQHekOrTc1ZA==
   dependencies:
     "@element-plus/icons-vue" "^2.3.2"
     dompurify "^3.2.6"
     gridstack "^12.3.3"
     marked "^15.0.7"
-    sass "^1.90.0"
-    vue "^3.5.18"
 
-pennsieve-ui-library@1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/pennsieve-ui-library/-/pennsieve-ui-library-1.0.6.tgz#81729171c90acc492769d1e54bd5e12d714066df"
-  integrity sha512-XIGG94XCsrIH7i5JvFZFwN5ON0ao/W4se7sGpkXh1WpNsPaF9E2LUTkULi9bodwHQHipMx0vdXSAYgXLnN5HfA==
-  dependencies:
-    moment "^2.30.1"
-    ramda "^0.30.1"
-    sass "^1.79.5"
-    vue "3.5.13"
+pennsieve-ui-library@1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/pennsieve-ui-library/-/pennsieve-ui-library-1.0.8.tgz#50b53ee8acf4fd80409ce6f721474803823f8db3"
+  integrity sha512-AwFXVY2zLFBPDu8d18kctZyRAZpzzjED+/URuLJ/6GOqRd8fBWGMlbAq/MgjDnVG+SN+b9DMaT9i0AdqJi2vZA==
 
 pennsieve-visualization@0.6.5:
   version "0.6.5"
@@ -6823,11 +6816,6 @@ ramda@^0.29.0:
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.29.1.tgz#408a6165b9555b7ba2fc62555804b6c5a2eca196"
   integrity sha512-OfxIeWzd4xdUNxlWhgFazxsA/nl3mS4/jGZI5n00uWOoSSFRhC1b6gl6xvmzUamgmqELraWp0J/qqVlXYPDPyA==
 
-ramda@^0.30.1:
-  version "0.30.1"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.30.1.tgz#7108ac95673062b060025052cd5143ae8fc605bf"
-  integrity sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==
-
 ramda@^0.31.3:
   version "0.31.3"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.31.3.tgz#0f54199ec99a7bd6702277d28d6bf7f93b916bb9"
@@ -7052,7 +7040,7 @@ safe-buffer@~5.2.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-sass@^1.79.5, sass@^1.90.0:
+sass@^1.79.5:
   version "1.99.0"
   resolved "https://registry.yarnpkg.com/sass/-/sass-1.99.0.tgz#ff9d1594da4886249dfaafabbeea2dea2dc74b26"
   integrity sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==
@@ -8022,7 +8010,7 @@ vue-social-sharing@^4.0.0-alpha4:
   resolved "https://registry.yarnpkg.com/vue-social-sharing/-/vue-social-sharing-4.0.0-alpha4.tgz#48d17f4ff2828c60689f2a065df86588af2bd1fb"
   integrity sha512-hMbgpZkY5aRAiznSB/sgzdMVgdSbkmIHEaELX7pUbuUd6KS1Z/GAi7a/q0Qn+GFn0+6qMMvwyp3ZOE0+WYPQ1w==
 
-vue@3.5.13, vue@3.5.32, vue@^3.5.13, vue@^3.5.18, vue@^3.5.30:
+vue@^3.5.13, vue@^3.5.30:
   version "3.5.32"
   resolved "https://registry.yarnpkg.com/vue/-/vue-3.5.32.tgz#9a7cbeb181aa4b2a71c3ebac4995542cf0353de3"
   integrity sha512-vM4z4Q9tTafVfMAK7IVzmxg34rSzTFMyIe0UUEijUCkn9+23lj0WRfA83dg7eQZIUlgOSGrkViIaCfqSAUXsMw==


### PR DESCRIPTION
  - New /dashboard page using pennsieve-dashboard library to display portal stats (datasets, total data, unique patients)
  - Added useDuckDB composable for in-browser SQL queries against bundled Parquet files
  - Added "Dashboard" nav link and external "CDE's" link to header
  - Replaced @element-plus/nuxt with manual Element Plus plugin
  - New deps: @duckdb/duckdb-wasm, pennsieve-dashboard, moment