### PR TITLE
update projects page for dev env

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -168,6 +168,7 @@ export default defineNuxtConfig({
       masterUserPW: process.env.MASTERUSER_PASSWORD,
       pennsieve_api_host: process.env.PENNSIEVE_API_HOST || "https://api.pennsieve.io",
       packages_api_host: process.env.PACKAGES_API_HOST || "https://api2.pennsieve.io/packages",
+      deploy_env: process.env.DEPLOY_ENV || "prod",
     },
   },
 

--- a/pages/projects/index.vue
+++ b/pages/projects/index.vue
@@ -23,10 +23,15 @@
 
 <script setup>
 const { $contentfulClient } = useNuxtApp()
+const runtimeConfig = useRuntimeConfig()
+
+const projectsContentType = runtimeConfig.public.deploy_env === "dev"
+  ? "devEnvironmentProject"
+  : "project"
 
 const { data: contentfulProjects, error, status } = useLazyAsyncData("projects", () => {
   return $contentfulClient.getEntries({
-    content_type: "project",
+    content_type: projectsContentType,
   });
 })
 


### PR DESCRIPTION
Use a separate Contentful content type for projects in dev

  - Expose DEPLOY_ENV as `deploy_env` in public runtime config
  - pages/projects/index.vue queries `devEnvironmentProject` when deploy_env === "dev", else `project`

  Lets the dev deployment surface in-progress projects from Contentful without affecting the prod projects list.