### PR TITLE
Feature zarr viewer

### DIFF
--- a/components/AccessibilityDialog/AccessibilityDialog.vue
+++ b/components/AccessibilityDialog/AccessibilityDialog.vue
@@ -1,4 +1,5 @@
 <template>
+  <client-only>
   <el-dialog
     v-model="showModal"
     :show-close="false"
@@ -38,6 +39,7 @@
       </div>
     </div>
   </el-dialog>
+  </client-only>
 </template>
 
 <script>

--- a/components/Dataset/ContributorItem/ContributorItem.vue
+++ b/components/Dataset/ContributorItem/ContributorItem.vue
@@ -6,6 +6,7 @@
       width="320"
       trigger="hover"
       popper-class="full-content orcid-popover"
+      :teleported="false"
       :disabled="!hasOrcid"
       @show="getOrcidData"
     >

--- a/components/Dataset/DatasetHeader/DatasetHeader.vue
+++ b/components/Dataset/DatasetHeader/DatasetHeader.vue
@@ -519,6 +519,7 @@ const isRehydrationModalVisible = ref(false)
                   :content="datasetLicenseName"
                   placement="top"
                   :visible-arrow="false"
+                  :teleported="false"
                 >
                   <a :href="licenseLink" target="_blank">
                     {{ datasetLicense }}

--- a/components/Dataset/DownloadDataset/DownloadDataset.vue
+++ b/components/Dataset/DownloadDataset/DownloadDataset.vue
@@ -168,6 +168,7 @@ function openRehydrationModal() {
 
 <template>
   <div>
+    <client-only>
     <el-dialog
       :modelValue="visible"
       :show-close="false"
@@ -273,6 +274,7 @@ function openRehydrationModal() {
         </div>
       </div>
     </el-dialog>
+    </client-only>
 
   </div>
 </template>

--- a/components/Dataset/RehydrationModal/RehydrationModal.vue
+++ b/components/Dataset/RehydrationModal/RehydrationModal.vue
@@ -114,6 +114,7 @@ async function submitRehydrationRequest() {
 
 <template>
   <div class="request-access-dialog">
+    <client-only>
     <el-dialog
       :modelValue="visible"
       :show-close="false"
@@ -167,6 +168,7 @@ async function submitRehydrationRequest() {
         <bf-button :prevent-click-event="true" @click="onFormSubmit">Submit</bf-button>
       </div>
     </el-dialog>
+    </client-only>
 
   </div>
 </template>

--- a/components/Dataset/VersionHistory/VersionHistory.vue
+++ b/components/Dataset/VersionHistory/VersionHistory.vue
@@ -33,6 +33,7 @@ function closeDialog() {
 
 <template>
   <div>
+    <client-only>
     <el-dialog
       :modelValue="visible"
       @update:modelValue="visible = $event"
@@ -86,6 +87,7 @@ function closeDialog() {
         </div>
       </div>
     </el-dialog>
+    </client-only>
 
   </div>
 </template>

--- a/components/Datasets/DatasetFiles/DatasetFiles.vue
+++ b/components/Datasets/DatasetFiles/DatasetFiles.vue
@@ -372,6 +372,7 @@ function handleTimeseriesDirectoryClick(row) {
       <input v-model="zipData" type="hidden" name="data" />
     </form>
 
+    <client-only>
     <el-dialog
       v-model="confirmDownloadVisible"
       :show-close="false"
@@ -432,6 +433,7 @@ function handleTimeseriesDirectoryClick(row) {
       </template>
 
     </el-dialog>
+    </client-only>
   </div>
 </template>
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -171,7 +171,7 @@ export default defineNuxtConfig({
       deploy_env: process.env.DEPLOY_ENV || "prod",
       orthogonal_viewer_url:
         process.env.PENNSIEVE_ORTHOGONAL_VIEWER_URL ||
-        "https://orthogonal-viewer.pennsieve.net",
+        "https://orthogonal-viewer.pennsieve.io",
     },
   },
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -169,6 +169,9 @@ export default defineNuxtConfig({
       pennsieve_api_host: process.env.PENNSIEVE_API_HOST || "https://api.pennsieve.io",
       packages_api_host: process.env.PACKAGES_API_HOST || "https://api2.pennsieve.io/packages",
       deploy_env: process.env.DEPLOY_ENV || "prod",
+      orthogonal_viewer_url:
+        process.env.PENNSIEVE_ORTHOGONAL_VIEWER_URL ||
+        "https://orthogonal-viewer.pennsieve.net",
     },
   },
 

--- a/pages/package/[id].vue
+++ b/pages/package/[id].vue
@@ -4,11 +4,13 @@ import { ref, onMounted, computed, shallowRef } from "vue";
 import { Markdown, TextViewer, CSVViewer } from "@pennsieve-viz/core";
 import "@pennsieve-viz/core/style.css";
 
-// Dynamic imports for browser-only tsviewer
+// Dynamic imports for browser-only viewers
 const TSViewer = shallowRef(null);
 const viewerStore = shallowRef(null);
 const tsViewerReady = ref(false);
 const tsViewerError = ref("");
+
+const OrthogonalFrame = shallowRef(null);
 
 let tsViewerLoaded = Promise.resolve();
 if (import.meta.client) {
@@ -16,6 +18,9 @@ if (import.meta.client) {
   tsViewerLoaded = import("@pennsieve-viz/tsviewer").then((module) => {
     TSViewer.value = module.TSViewer;
     viewerStore.value = module.createViewerStore("package-viewer");
+  });
+  import("@pennsieve-viz/core").then((module) => {
+    OrthogonalFrame.value = module.OrthogonalFrame;
   });
 }
 
@@ -30,6 +35,17 @@ const fileContent = ref("");
 const isLoadingContent = ref(false);
 const contentError = ref("");
 const { fetchFileContent } = useFileContent();
+
+// Orthogonal (Zarr) viewer state
+const NEUROGLANCER_ASSET_TYPES = ["ome-zarr", "neuroglancer-precomputed"];
+const orthogonalAssets = ref([]);
+const selectedAssetIndex = ref(0);
+const orthogonalEmbedUrl = runtimeConfig.public.orthogonal_viewer_url;
+
+const selectedOrthogonalAsset = computed(
+  () => orthogonalAssets.value[selectedAssetIndex.value] || null
+);
+const hasOrthogonalAssets = computed(() => orthogonalAssets.value.length > 0);
 
 const timeseriesFileTypes = ["MEF", "EDF", "BDF", "NWB"]
 const csvFileTypes = ["CSV", "TSV"]
@@ -54,7 +70,17 @@ async function fetchViewerAssets(sourcePackageId) {
   const url = `${runtimeConfig.public.packages_api_host}/discover/assets?package_id=${encodeURIComponent(sourcePackageId)}`;
   try {
     const response = await useSendXhr(url, { method: "GET" });
-    return response?.assets || [];
+    const cloudfront = response?.cloudfront || null;
+    const seen = new Set();
+    const assets = (response?.assets || [])
+      .filter((a) => {
+        if (a.status !== "ready") return false;
+        if (seen.has(a.asset_url)) return false;
+        seen.add(a.asset_url);
+        return true;
+      })
+      .map((a) => ({ ...a, cloudfront }));
+    return assets;
   } catch {
     return [];
   }
@@ -118,14 +144,24 @@ function processFileData(fileData, datasetId, version) {
   if ([...csvFileTypes, ...imageFileTypes].includes(type)) {
     fetchPresignedUrl(fileData.path, datasetId, version);
   }
-  if (timeseriesFileTypes.includes(type)) {
-    const sourcePackageId = fileData.sourcePackageId || route.params.id;
-    fetchViewerAssets(sourcePackageId).then((assets) => {
-      const assetId = assets.length > 0 ? assets[0].id : undefined;
-      console.log('asset id is' , assetId)
-      initTimeseriesViewer(sourcePackageId, assetId);
-    });
-  }
+
+  // Fetch all viewer assets and categorize them
+  const sourcePackageId = fileData.sourcePackageId || route.params.id;
+  fetchViewerAssets(sourcePackageId).then((assets) => {
+    const tsAssets = assets.filter((a) => a.asset_type === "timeseries");
+    const ngAssets = assets.filter((a) => NEUROGLANCER_ASSET_TYPES.includes(a.asset_type));
+
+    if (ngAssets.length > 0) {
+      orthogonalAssets.value = ngAssets;
+      selectedAssetIndex.value = 0;
+    }
+
+    if (timeseriesFileTypes.includes(type) && tsAssets.length > 0) {
+      initTimeseriesViewer(sourcePackageId, tsAssets[0].id);
+    } else if (timeseriesFileTypes.includes(type)) {
+      initTimeseriesViewer(sourcePackageId, undefined);
+    }
+  });
 }
 
 async function fetchFromSourcePackageId(sourcePackageId, datasetId, version) {
@@ -193,10 +229,40 @@ onMounted(() => {
     <package-details class="package-details-content" />
 
     <div class="package-viewer">
-      <h3 v-if="isReady" class="viewer-title">File Viewer</h3>
+      <h3 v-if="isReady || hasOrthogonalAssets" class="viewer-title">
+        {{ hasOrthogonalAssets ? 'Orthogonal Viewer' : 'File Viewer' }}
+      </h3>
+
+      <!-- Asset tabs when multiple orthogonal assets -->
+      <div v-if="hasOrthogonalAssets && orthogonalAssets.length > 1" class="viewer-tabs">
+        <button
+          v-for="(asset, idx) in orthogonalAssets"
+          :key="asset.asset_url"
+          class="viewer-tab"
+          :class="{ 'viewer-tab--active': idx === selectedAssetIndex }"
+          type="button"
+          @click="selectedAssetIndex = idx"
+        >
+          {{ asset.name }}
+        </button>
+      </div>
+
       <div class="viewer-wrapper">
+        <!-- Orthogonal (Zarr) Viewer -->
+        <client-only v-if="hasOrthogonalAssets && selectedOrthogonalAsset">
+          <component
+            v-if="OrthogonalFrame"
+            :is="OrthogonalFrame"
+            :key="selectedOrthogonalAsset.asset_url"
+            :source="selectedOrthogonalAsset.asset_url"
+            :embed-url="orthogonalEmbedUrl"
+            :cloudfront="selectedOrthogonalAsset.cloudfront || null"
+          />
+          <div v-else class="viewer-message">Loading orthogonal viewer...</div>
+        </client-only>
+
         <!-- Loading State -->
-        <div v-if="!isReady" class="viewer-message">
+        <div v-else-if="!isReady" class="viewer-message">
           Loading viewer...
         </div>
 
@@ -292,6 +358,33 @@ onMounted(() => {
   text-transform: uppercase;
   letter-spacing: 0.6px;
   margin: 0 0 12px;
+}
+
+.viewer-tabs {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 1rem;
+  border-bottom: 1px solid $gray_2;
+}
+
+.viewer-tab {
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: 8px 16px;
+  font-size: 14px;
+  font-weight: 500;
+  color: $gray_4;
+  cursor: pointer;
+
+  &:hover {
+    color: $purple_1;
+  }
+
+  &--active {
+    color: $purple_1;
+    border-bottom-color: $purple_1;
+  }
 }
 
 .viewer-wrapper {

--- a/pages/package/[id].vue
+++ b/pages/package/[id].vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useMainStore } from "~/store/index.js";
-import { ref, onMounted, computed, shallowRef } from "vue";
+import { ref, onMounted, computed, shallowRef, nextTick } from "vue";
 import { Markdown, TextViewer, CSVViewer } from "@pennsieve-viz/core";
 import "@pennsieve-viz/core/style.css";
 
@@ -52,17 +52,29 @@ const csvFileTypes = ["CSV", "TSV"]
 const textFileTypes = ["TXT", "JSON", "XML", "LOG", "YAML", "YML"]
 const markdownFileTypes = ["MD", "MARKDOWN"]
 const imageFileTypes = ["PNG", "JPG", "JPEG", "GIF", "SVG", "WEBP", "BMP", "ICO"]
+const neuroglancerFileTypes = ["NII", "NII.GZ", "ZARR", "OME.TIFF", "OME.TIF"]
 
 const isReady = computed(() => !isLoading.value && !!fileType.value)
+const isLoadingAssets = ref(false)
+
+const resolvedFileType = computed(() => {
+  const type = fileType.value.toUpperCase()
+  const uri = fileUri.value.toLowerCase()
+  // Handle compound extensions
+  if (type === "GZ" && uri.endsWith(".nii.gz")) return "NII.GZ"
+  if ((type === "TIFF" || type === "TIF") && uri.match(/\.ome\.tiff?$/)) return "OME.TIFF"
+  return type
+})
 
 const viewerType = computed(() => {
   if (!isReady.value) return null
-  const type = fileType.value.toUpperCase()
+  const type = resolvedFileType.value
   if (timeseriesFileTypes.includes(type)) return "timeseries"
   if (csvFileTypes.includes(type)) return "csv"
   if (markdownFileTypes.includes(type)) return "markdown"
   if (textFileTypes.includes(type)) return "text"
   if (imageFileTypes.includes(type)) return "image"
+  if (neuroglancerFileTypes.includes(type)) return "neuroglancer"
   return "unsupported"
 })
 
@@ -134,10 +146,11 @@ async function initTimeseriesViewer(sourcePackageId, assetId) {
   }
 }
 
-function processFileData(fileData, datasetId, version) {
+async function processFileData(fileData, datasetId, version) {
   fileType.value = fileData.fileType || "";
-  fileUri.value = fileData.uri || "";
-  const type = fileType.value.toUpperCase();
+  fileUri.value = fileData.uri || fileData.path || "";
+  await nextTick();
+  const type = resolvedFileType.value;
   if ([...textFileTypes, ...markdownFileTypes].includes(type)) {
     loadFileContent(fileData, datasetId, version);
   }
@@ -147,6 +160,7 @@ function processFileData(fileData, datasetId, version) {
 
   // Fetch all viewer assets and categorize them
   const sourcePackageId = fileData.sourcePackageId || route.params.id;
+  isLoadingAssets.value = true;
   fetchViewerAssets(sourcePackageId).then((assets) => {
     const tsAssets = assets.filter((a) => a.asset_type === "timeseries");
     const ngAssets = assets.filter((a) => NEUROGLANCER_ASSET_TYPES.includes(a.asset_type));
@@ -161,6 +175,8 @@ function processFileData(fileData, datasetId, version) {
     } else if (timeseriesFileTypes.includes(type)) {
       initTimeseriesViewer(sourcePackageId, undefined);
     }
+  }).finally(() => {
+    isLoadingAssets.value = false;
   });
 }
 
@@ -322,6 +338,14 @@ onMounted(() => {
             :alt="fileType"
             class="image-viewer"
           />
+        </div>
+
+        <!-- Neuroglancer file type waiting for assets -->
+        <div v-else-if="viewerType === 'neuroglancer' && isLoadingAssets" class="viewer-message">
+          Loading viewer...
+        </div>
+        <div v-else-if="viewerType === 'neuroglancer' && !hasOrthogonalAssets" class="viewer-message">
+          No viewer assets available for this file.
         </div>
 
         <!-- Unsupported -->


### PR DESCRIPTION
  ## Changes                                                                                                                                                                                                                 
                                                                                                                                                                                                                           
  ### OrthogonalFrame Zarr Viewer (`pages/package/[id].vue`, `nuxt.config.ts`)
  - Integrate OrthogonalFrame from `@pennsieve-viz/core` for viewing ome-zarr and neuroglancer-precomputed assets
  - Add neuroglancer file type recognition: `.nii.gz`, `.ome.tiff`, `.ome.tif`, `.zarr`, `.nii`
  - Handle compound file extensions (e.g. `.nii.gz` reported as `GZ` by API)
  - Fetch viewer assets from packages API and pass CloudFront signed cookies to OrthogonalFrame
  - Support multiple orthogonal assets with tab switching
  - Add `orthogonal_viewer_url` runtime config (defaults to `orthogonal-viewer.pennsieve.io`)
  - Use `nextTick` before reading resolved file type to avoid stale reactive state

  ### Element Plus SSR Hydration Fixes
  - Wrap `el-dialog` in `<client-only>` in 5 components:
    - `AccessibilityDialog`
    - `DownloadDataset`
    - `RehydrationModal`
    - `VersionHistory`
    - `DatasetFiles`
  - Add `:teleported="false"` to `el-popover` in `ContributorItem`
  - Add `:teleported="false"` to `el-tooltip` in `DatasetHeader`