### PR TITLE
Fix viewer height to use height instead of min-height

### DIFF
--- a/pages/package/[id].vue
+++ b/pages/package/[id].vue
@@ -412,7 +412,7 @@ onMounted(() => {
 }
 
 .viewer-wrapper {
-  min-height: 85vh;
+  height: 85vh;
 }
 
 .viewer-message {


### PR DESCRIPTION
The orthogonal-frame component uses height:inherit, so the parent needs an explicit height for the iframe to fill the space.